### PR TITLE
make plugin refreshing configurable

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -157,6 +157,9 @@ environments {
     development {
         server.online = !System.getProperty('offline')
         if (!server.online) { println 'Config: working offline' }
+        plugin {
+            refreshDelay = 5000
+        }
     }
     test {
         server.online = false

--- a/grails-app/conf/spring/resources.groovy
+++ b/grails-app/conf/spring/resources.groovy
@@ -46,6 +46,6 @@ beans = {
     pluginDir.eachFileMatch(FileType.FILES, ~/.*\.groovy/) { File plugin ->
         String beanName = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, plugin.name.replace('.groovy', ''))
         lang.groovy(id: beanName, 'script-source': "file:${application.config.asgardHome}/plugins/${plugin.name}",
-            'refresh-check-delay': 5000)
+            'refresh-check-delay': application.config.plugin.refreshDelay?: -1)
     }
 }


### PR DESCRIPTION
Possible cause for some of our problems for the last week, though I don't have any evidence to support this. The refreshing wasn't working in test/production anyway.

This will keep refreshing of the plugin Groovy scripts in our development environments, but disable it for all others.

Disregard the first two commits - I created the branch wrong, but it looks like those two changes will be no-ops with public/master.
