### PR TITLE
optimize health check calls for resize operations

### DIFF
--- a/src/groovy/com/netflix/asgard/push/GroupResizeOperation.groovy
+++ b/src/groovy/com/netflix/asgard/push/GroupResizeOperation.groovy
@@ -278,7 +278,7 @@ class GroupResizeOperation {
         ensureTrafficIsSuppressedIfAppropriate(group)
         Collection<String> idsOfInstancesThatAreNotYetHealthy = findInstancesNotYetHealthy(group.instances*.instanceId)
         if (idsOfInstancesThatAreNotYetHealthy.empty) {
-            // Everything is healthy, our work is done here
+            // Everything is healthy. Our work is done here.
             return group
         }
         // Loop until everything not yet healthy is healthy


### PR DESCRIPTION
As Joe pointed out the other day, we stagger calls for unhealthy instances in the getRepleatedResponse() call, which should keep polling from eating too much CPU while resizing. However, if we're resizing and a majority of the instances are healthy, this can lead to a burst of health check calls to instances we already know are healthy, slowing down performance.

This commit to change the polling to only check the unhealthy instances. Once the yet to be healthy instances have all passed their health check, we do a final call to make sure any of the other instances haven't become unhealthy while waiting.

Still testing this, since I can't get a app with a working healthcheck up.
