### PR TITLE
Cluster show performance

### DIFF
--- a/grails-app/controllers/com/netflix/asgard/ClusterController.groovy
+++ b/grails-app/controllers/com/netflix/asgard/ClusterController.groovy
@@ -104,7 +104,7 @@ class ClusterController {
                         cluster.size() <= 1 ? 'Create a new group and switch traffic to it' :
                         'Switch traffic to the preferred group, then delete legacy group'
                     Collection<Task> runningTasks = taskService.getRunningTasksByObject(Link.to(EntityType.cluster,
-                        cluster.name), userContext.region)
+                            cluster.name), userContext.region)
 
                     boolean showAllImages = params.allImages ? true : false
                     Map attributes = pushService.prepareEdit(userContext, lastGroup.autoScalingGroupName, showAllImages,


### PR DESCRIPTION
The latest foray into profiling showed a bottleneck in the json api for show cluster. The hotspots were in PushService calls, which are actually attributes only used by the html interface.
