### PR TITLE
Asgard startup should not throw FileNotFoundException on virgin machine

### DIFF
--- a/grails-app/conf/spring/resources.groovy
+++ b/grails-app/conf/spring/resources.groovy
@@ -42,10 +42,11 @@ beans = {
     xmlns lang:'http://www.springframework.org/schema/lang'
 
     File pluginDir = new File("${application.config.asgardHome}/plugins/")
-
-    pluginDir.eachFileMatch(FileType.FILES, ~/.*\.groovy/) { File plugin ->
-        String beanName = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, plugin.name.replace('.groovy', ''))
-        lang.groovy(id: beanName, 'script-source': "file:${application.config.asgardHome}/plugins/${plugin.name}",
-            'refresh-check-delay': application.config.plugin.refreshDelay?: -1)
+    if (pluginDir.exists()) {
+        pluginDir.eachFileMatch(FileType.FILES, ~/.*\.groovy/) { File plugin ->
+            String beanName = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, plugin.name.replace('.groovy', ''))
+            lang.groovy(id: beanName, 'script-source': "file:${application.config.asgardHome}/plugins/${plugin.name}",
+                    'refresh-check-delay': application.config.plugin.refreshDelay?: -1)
+        }
     }
 }


### PR DESCRIPTION
My MacBook Air had never run asgard or had a .asgard directory. I tried running freshly downloaded tomcat 7 with latest Jenkins asgard war and got this error in asgard.log:
`java.io.FileNotFoundException: /Users/main/.asgard/plugins
at resources$_run_closure1.doCall(resources.groovy:46)`
This change prevents that error.
