### PR TITLE
ASGARD-890 - Allow use of amazon public AMIs for new asgard users.

### DIFF
--- a/grails-app/controllers/com/netflix/asgard/InitController.groovy
+++ b/grails-app/controllers/com/netflix/asgard/InitController.groovy
@@ -61,6 +61,7 @@ class InitializeCommand {
     String accessId
     String secretKey
     String accountNumber
+    boolean showPublicAmazonImages
     static constraints = {
         accessId(nullable: false, blank: false, matches: /[A-Z0-9]{20}/)
         secretKey(nullable: false, blank: false, matches: /[A-Za-z0-9\+\/]{40}/)
@@ -83,6 +84,7 @@ class InitializeCommand {
         ConfigObject cloudConfig = new ConfigObject()
         rootConfig['cloud'] = cloudConfig
         cloudConfig['accountName'] = 'prod'
+        cloudConfig['publicResourceAccounts'] = showPublicAmazonImages ? ['amazon'] : []
 
         rootConfig
     }

--- a/grails-app/services/com/netflix/asgard/AwsEc2Service.groovy
+++ b/grails-app/services/com/netflix/asgard/AwsEc2Service.groovy
@@ -146,7 +146,8 @@ class AwsEc2Service implements CacheInitializer, InitializingBean {
     // Images
 
     private List<Image> retrieveImages(Region region) {
-        DescribeImagesRequest request = new DescribeImagesRequest().withOwners(accounts)
+        List<String> publicAccounts = configService.publicResourceAccounts
+        DescribeImagesRequest request = new DescribeImagesRequest().withOwners(accounts + publicAccounts)
         AmazonEC2 awsClientForRegion = awsClient.by(region)
         List<Image> images = awsClientForRegion.describeImages(request).getImages()
         // Temporary workaround because Amazon can send us the list of images without the tags occasionally.

--- a/grails-app/services/com/netflix/asgard/ConfigService.groovy
+++ b/grails-app/services/com/netflix/asgard/ConfigService.groovy
@@ -97,6 +97,15 @@ class ConfigService {
         grailsApplication.config?.grails?.awsAccounts ?: []
     }
 
+    /**
+     * Gets the optional list of accounts whose public resources such as AMIs should be used.
+     *
+     * @return List < String > account numbers/names, or empty list if not configured
+     */
+    List<String> getPublicResourceAccounts() {
+        grailsApplication.config?.cloud?.publicResourceAccounts ?: []
+    }
+
     List<String> getDiscouragedAvailabilityZones() {
         grailsApplication.config?.cloud?.discouragedAvailabilityZones ?: []
     }

--- a/grails-app/views/image/_amis.gsp
+++ b/grails-app/views/image/_amis.gsp
@@ -36,7 +36,7 @@
   <tbody>
   <g:each var="image" in="${images}" status="i">
     <tr class="${(i % 2) == 0 ? 'odd' : 'even'}">
-      <td><g:linkObject name="${image.imageId}" /></td>
+      <td><g:linkObject type="image" name="${image.imageId}"/></td>
       <td>
         <g:each var="mergedInstance" in="${imageIdsToInstanceLists[image.imageId]}">
           <g:linkObject name="${mergedInstance.instanceId}"/>
@@ -45,7 +45,7 @@
         </g:each>
       </td>
       <td><g:formatDate date="${image.baseAmiDate?.toDate()}"/></td>
-      <td><g:linkObject name="${image.baseAmiId}" /></td>
+      <td><g:linkObject type="image" name="${image.baseAmiId}"/></td>
       <td>${image.baseAmiName}</td>
       <td class="ami">${image.name}</td>
       <td class="ami">${image.imageLocation}</td>

--- a/grails-app/views/image/analyze.gsp
+++ b/grails-app/views/image/analyze.gsp
@@ -66,7 +66,7 @@
           <td>${appVersionToImageList.value.size()}</td>
           <td>
             <g:each in="${appVersionToImageList.value}" var="image">
-              <g:linkObject name="${image.imageId}" />
+              <g:linkObject type="image" name="${image.imageId}"/>
             </g:each>
           </td>
         </tr>

--- a/grails-app/views/image/list.gsp
+++ b/grails-app/views/image/list.gsp
@@ -51,7 +51,7 @@
         <tbody>
         <g:each var="image" in="${images}" status="i">
           <tr class="${(i % 2) == 0 ? 'odd' : 'even'}">
-            <td><g:linkObject name="${image.imageId}"/></td>
+            <td><g:linkObject type="image" name="${image.imageId}"/></td>
             <td class="ami">${image.name}</td>
             <td class="ami">${image.imageLocation}</td>
             <td>${image.architecture}</td>
@@ -61,7 +61,7 @@
             <td>${image.creationTime}</td>
             <td>${image.lastReferencedTime}</td>
             <td class="ami">${image.appVersion}</td>
-            <td><g:linkObject name="${image.baseAmiId}"/></td>
+            <td><g:linkObject type="image" name="${image.baseAmiId}"/></td>
             <td><g:formatDate date="${image.baseAmiDate?.toDate()}" /></td>
           </tr>
         </g:each>

--- a/grails-app/views/init/index.gsp
+++ b/grails-app/views/init/index.gsp
@@ -28,7 +28,7 @@
     <h1>For more advanced configuration, please consult the the documentation.</h1>
     <g:if test="${flash.message}">
       <div class="message">${flash.message}</div>
-    </g:if>    
+    </g:if>
     <g:hasErrors bean="${cmd}">
       <div class="errors">
         <g:renderErrors bean="${cmd}" as="list"/>
@@ -40,21 +40,30 @@
           <tbody>
             <tr class="prop">
               <td class="name">
-                <label>Access Key ID:</label>
+                <label for="accessId">Access Key ID:</label>
               </td>
               <td class="value"><input type="text" size='25' maxlength='20' id="accessId" name="accessId" value="${params.accessId}" class="required"/></td>
             </tr>
             <tr class="prop">
               <td class="name">
-                <label>Secret Access Key:</label>
+                <label for="secretKey">Secret Access Key:</label>
               </td>
-              <td class="value"><input type="text" size='50' maxlength='40' id="secretKey" name="secretKey" value="${params.secretKey}" class="required"/></td>
+              <td class="value"><input type="password" size='50' maxlength='40' id="secretKey" name="secretKey" value="${params.secretKey}" class="required"/></td>
             </tr>
             <tr class="prop">
               <td class="name">
-                <label>AWS Account Number:</label>
+                <label for="accountNumber">AWS Account Number:</label>
               </td>
               <td class="value"><input type="text" size='15' maxlength='14' id="accountNumber" name="accountNumber" value="${params.accountNumber}" class="required"/></td>
+            </tr>
+            <tr class="prop" title="Keep this flag checked to allow display and use of public Amazon images">
+              <td class="name">
+                <label for="showPublicAmazonImages">Use public Amazon images:</label>
+              </td>
+              <td class="value">
+                %{--Pre-check initially (no cmd). On validation failure retain user choice.--}%
+                <input type="checkbox" ${params.showPublicAmazonImages || !cmd ? 'checked="checked"' : ''} id="showPublicAmazonImages" name="showPublicAmazonImages"/>
+              </td>
             </tr>
           </tbody>
         </table>
@@ -62,7 +71,7 @@
       <div class="buttons">
         <g:buttonSubmit class="save" value="save">Save</g:buttonSubmit>
       </div>
-    </g:form>     
+    </g:form>
   </div>
 </body>
 </html>

--- a/src/groovy/com/netflix/asgard/EntityType.groovy
+++ b/src/groovy/com/netflix/asgard/EntityType.groovy
@@ -66,8 +66,7 @@ import java.lang.reflect.Modifier
     static final EntityType<FastProperty> fastProperty = create('Fast Property', { it.id })
     static final EntityType<HardwareProfile> hardwareProfile = create('Hardware Profile',
             { it.instanceType.toString() })
-    static final EntityType<Image> image = create('Image', { it.imageId }, 'ami-',
-            'Show details of this Amazon machine image')
+    static final EntityType<Image> image = create('Image', { it.imageId })
     static final EntityType<Instance> instance = create('Instance', { it.instanceId }, 'i-')
     static final EntityType<InstanceTypeData> instanceType = create('Instance Type', { it.name })
     static final EntityType<KeyPairInfo> keyPair = create('Key Pair', { it.keyName })


### PR DESCRIPTION
Keep the public AMIs out of Netflix's image list.
Some public images start with "aki-" so remove assumption that all images start with "ami-"
Also improve init screen usability a little. Password field to hide secret key. Clickable labels to go with existing input ID attributes.
