### PR TITLE
ASGARD-892 - OSS asgard users should have red header by default

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -164,7 +164,7 @@ environments {
     test {
         server.online = false
     }
-    prod {
+    production {
         cloud {
             envStyle = 'prod'
         }


### PR DESCRIPTION
The default Config.groovy specifies the header style for new OSS users, but it does so incorrectly by configuring a non-existent "prod" environment instead of the Grails default "production" environment.
