### PR TITLE
Fix unit tests that broke after adding ability to use public Amazon AMIs

### DIFF
--- a/grails-app/services/com/netflix/asgard/AwsEc2Service.groovy
+++ b/grails-app/services/com/netflix/asgard/AwsEc2Service.groovy
@@ -100,7 +100,7 @@ class AwsEc2Service implements CacheInitializer, InitializingBean {
     Caches caches
     def restClientService
     def taskService
-    List<String> accounts  // main account is accounts[0]
+    List<String> accounts = [] // main account is accounts[0]
 
     /** The state names for instances that count against reservation usage. */
     private static final List<String> ACTIVE_INSTANCE_STATES = ['pending', 'running'].asImmutable()
@@ -146,8 +146,8 @@ class AwsEc2Service implements CacheInitializer, InitializingBean {
     // Images
 
     private List<Image> retrieveImages(Region region) {
-        List<String> publicAccounts = configService.publicResourceAccounts
-        DescribeImagesRequest request = new DescribeImagesRequest().withOwners(accounts + publicAccounts)
+        List<String> owners = configService.publicResourceAccounts + accounts
+        DescribeImagesRequest request = new DescribeImagesRequest().withOwners(owners)
         AmazonEC2 awsClientForRegion = awsClient.by(region)
         List<Image> images = awsClientForRegion.describeImages(request).getImages()
         // Temporary workaround because Amazon can send us the list of images without the tags occasionally.

--- a/test/unit/com/netflix/asgard/AwsEc2ServiceTests.groovy
+++ b/test/unit/com/netflix/asgard/AwsEc2ServiceTests.groovy
@@ -27,6 +27,7 @@ import com.amazonaws.services.ec2.model.Tag
 import com.google.common.collect.Multiset
 import com.netflix.asgard.mock.Mocks
 import grails.test.GrailsUnitTestCase
+import grails.test.MockUtils
 
 class AwsEc2ServiceTests extends GrailsUnitTestCase {
 
@@ -128,6 +129,7 @@ class AwsEc2ServiceTests extends GrailsUnitTestCase {
         Image image1 = new Image(imageId: 'imageId1', tags: [new Tag()])
         Image image2 = new Image(imageId: 'imageId2', tags: [new Tag()])
         AwsEc2Service awsEc2Service = new AwsEc2Service()
+        awsEc2Service.configService = Mocks.configService()
         def mockAmazonEC2 = mockFor(AmazonEC2)
         awsEc2Service.awsClient = new MultiRegionAwsClient({ mockAmazonEC2.createMock() })
         DescribeImagesResult describeImagesResult = new DescribeImagesResult(images: [image1, image2])
@@ -142,6 +144,8 @@ class AwsEc2ServiceTests extends GrailsUnitTestCase {
         Image image1 = new Image(imageId: 'imageId1')
         Image image2 = new Image(imageId: 'imageId2')
         AwsEc2Service awsEc2Service = new AwsEc2Service()
+        MockUtils.mockLogging(AwsEc2Service)
+        awsEc2Service.configService = Mocks.configService()
         def mockAmazonEC2 = mockFor(AmazonEC2)
         awsEc2Service.awsClient = new MultiRegionAwsClient({ mockAmazonEC2.createMock() })
         DescribeImagesResult describeImagesResultMissingTags = new DescribeImagesResult(images: [image1, image2])

--- a/test/unit/com/netflix/asgard/EntityTypeSpec.groovy
+++ b/test/unit/com/netflix/asgard/EntityTypeSpec.groovy
@@ -23,9 +23,9 @@ class EntityTypeSpec extends Specification {
         expect:
         EntityType.instance == EntityType.fromId('i-1bd7b278')
         EntityType.spotInstanceRequest == EntityType.fromId('sir-cd1a3e14')
-        EntityType.image == EntityType.fromId('ami-8ceb1be5')
         EntityType.volume == EntityType.fromId('vol-06892b6c')
         EntityType.snapshot == EntityType.fromId('snap-00b46468')
+        null == EntityType.fromId('ami-8ceb1be5')
         null == EntityType.fromId('  i-1bd7b278  ')
         null == EntityType.fromId('nflx-1234')
         null == EntityType.fromId('blah')

--- a/test/unit/com/netflix/asgard/ImageControllerTests.groovy
+++ b/test/unit/com/netflix/asgard/ImageControllerTests.groovy
@@ -38,7 +38,7 @@ class ImageControllerTests extends ControllerUnitTestCase {
     }
 
     void testShowNonExistent() {
-        controller.params.imageId ='doesntexist'
+        controller.params.imageId ='ami-doesntexist'
         controller.show()
         assert '/error/missing' == controller.renderArgs.view
         assert "Image 'ami-doesntexist' not found in us-east-1 test" == controller.flash.message


### PR DESCRIPTION
(Also fixing my email filters to catch latest Jenkins job names so I won't leave the build broken next time)
