### PR TITLE
Suppress IntelliJ warnings on Spock syntax.

### DIFF
--- a/test/unit/com/netflix/asgard/SecurityControllerSpec.groovy
+++ b/test/unit/com/netflix/asgard/SecurityControllerSpec.groovy
@@ -25,6 +25,7 @@ import com.netflix.asgard.mock.Mocks
 import grails.plugin.spock.ControllerSpec
 import grails.test.MockUtils
 
+@SuppressWarnings("GroovyPointlessArithmetic")
 class SecurityControllerSpec extends ControllerSpec {
     AmazonEC2 amazonEC2 = Mock(AmazonEC2)
 


### PR DESCRIPTION
This class escaped my notice in the last code clean up pass.
