### PR TITLE
Version of license-gradle-plugin switched to the stable 0.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.6.0-SNAPSHOT'
+        classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.6.0'
     }
 }
 


### PR DESCRIPTION
Please, use stable version 0.6.0 of artifact  group:nl.javadude.gradle.plugins, module:license-gradle-plugin.
Build failed for me with currently used 0.6.0-SNAPSHOT.
