### PR TITLE
ASGARD-912 - Fix sorttable JavaScript error on ELB detail screen

### DIFF
--- a/grails-app/views/loadBalancer/show.gsp
+++ b/grails-app/views/loadBalancer/show.gsp
@@ -71,7 +71,7 @@
                       <th>Protocol</th>
                       <th>Load Balancer Port</th>
                       <th>Instance Port</th>
-                      <th></th>
+                      <th class="sorttable_nosort"></th>
                     </tr>
                   </thead>
                   <g:each var="listenerDescription" in="${loadBalancer.listenerDescriptions.sort { it.listener.loadBalancerPort }}" status="i">


### PR DESCRIPTION
The last column of the sortable list of listeners on the ELB detail screen contains elements that sortable.js does not know how to deal with. The JS error prevents us from adding a second sortable table to that page. Avoid the error by marking that last column with class sorttable_nosort so that sortable.js won't even try to determine the values in that column. This change will enable the adding of a second sortable table to that screen.
