### PR TITLE
ASGARD-944 - Remove paginate tags containing unsafe count() calls

### DIFF
--- a/grails-app/views/application/list.gsp
+++ b/grails-app/views/application/list.gsp
@@ -64,7 +64,6 @@
       </table>
     </div>
     <div class="paginateButtons">
-      <g:paginate total="${applications.count()}"/>
     </div>
   </g:form>
 </div>

--- a/grails-app/views/autoScaling/list.gsp
+++ b/grails-app/views/autoScaling/list.gsp
@@ -114,7 +114,6 @@
       </table>
     </div>
     <div class="paginateButtons">
-      <g:paginate total="${autoScalingGroups.count()}"/>
     </div>
   </g:form>
 </div>

--- a/grails-app/views/dbSecurity/list.gsp
+++ b/grails-app/views/dbSecurity/list.gsp
@@ -60,7 +60,6 @@
       </table>
     </div>
     <div class="paginateButtons">
-      <g:paginate total="${dbSecurityGroups.count()}"/>
     </div>
   </g:form>
 </div>

--- a/grails-app/views/dbSnapshot/list.gsp
+++ b/grails-app/views/dbSnapshot/list.gsp
@@ -59,7 +59,6 @@
         </table>
       </div>
       <div class="paginateButtons">
-        <g:paginate total="${snapshots.count()}"/>
       </div>
     </g:form>
   </div>

--- a/grails-app/views/image/list.gsp
+++ b/grails-app/views/image/list.gsp
@@ -68,7 +68,6 @@
       </table>
     </div>
     <div class="paginateButtons">
-      <g:paginate total="${images.count()}"/>
     </div>
   </g:form>
 </div>

--- a/grails-app/views/instance/list.gsp
+++ b/grails-app/views/instance/list.gsp
@@ -37,7 +37,6 @@
         </div>
       </g:render>
       <div class="paginateButtons">
-        <g:paginate total="${instanceList.count()}"/>
       </div>
     </g:form>
   </div>

--- a/grails-app/views/launchConfiguration/list.gsp
+++ b/grails-app/views/launchConfiguration/list.gsp
@@ -60,7 +60,6 @@
       </table>
     </div>
     <div class="paginateButtons">
-      <g:paginate total="${launchConfigurations.count()}"/>
     </div>
   </g:form>
 </div>

--- a/grails-app/views/loadBalancer/list.gsp
+++ b/grails-app/views/loadBalancer/list.gsp
@@ -81,7 +81,6 @@
       </table>
     </div>
     <div class="paginateButtons">
-      <g:paginate total="${loadbalancers.count()}"/>
     </div>
   </g:form>
 </div>

--- a/grails-app/views/rdsInstance/list.gsp
+++ b/grails-app/views/rdsInstance/list.gsp
@@ -65,7 +65,6 @@
         </table>
       </div>
     <div class="paginateButtons">
-        <g:paginate total="${dbInstanceList.count()}"/>
     </div>
     </g:form>
   </div>

--- a/grails-app/views/security/list.gsp
+++ b/grails-app/views/security/list.gsp
@@ -59,7 +59,6 @@
       </table>
     </div>
     <div class="paginateButtons">
-      <g:paginate total="${securityGroups.count()}"/>
     </div>
   </g:form>
 </div>

--- a/grails-app/views/snapshot/list.gsp
+++ b/grails-app/views/snapshot/list.gsp
@@ -71,7 +71,6 @@
         </table>
       </div>
       <div class="paginateButtons">
-        <g:paginate total="${snapshots.count()}"/>
       </div>
     </g:form>
   </div>

--- a/grails-app/views/task/list.gsp
+++ b/grails-app/views/task/list.gsp
@@ -67,7 +67,6 @@
         </table>
       </div>
       <div class="paginateButtons">
-        <g:paginate total="${runningTaskList.count()}"/>
       </div>
     </g:form>
   </div>
@@ -108,7 +107,6 @@
       </table>
     </div>
     <div class="paginateButtons">
-      <g:paginate total="${completedTaskList.count()}"/>
     </div>
   </div>
 </body>

--- a/grails-app/views/volume/list.gsp
+++ b/grails-app/views/volume/list.gsp
@@ -71,7 +71,6 @@
           </table>
       </div>
       <div class="paginateButtons">
-        <g:paginate total="${volumes.count()}"/>
       </div>
     </g:form>
   </div>


### PR DESCRIPTION
- Grails 2 requires this fix.
- At least one open source user has seen this
  error in some environment, possibly Ubuntu or
  OpenJDK or some other quirky dependency of Groovy/Grails.
- These tags never did anything anyway.

Keep the empty div for the usability bonus of seeing a buffer
object when scrolling to the bottom of the list. Just remove the
paginate tags.
