### PR TITLE
Asgard 964 - Improve order of columns on fast property list

### DIFF
--- a/grails-app/views/fastProperty/list.gsp
+++ b/grails-app/views/fastProperty/list.gsp
@@ -59,7 +59,7 @@
             <td>${fastProperty?.ts}</td>
             <td class="updatedBy">${fastProperty?.updatedBy?.encodeAsHTML()}</td>
             <td class="sourceOfUpdate">${fastProperty?.sourceOfUpdate?.encodeAsHTML()}</td>
-            <td>${fastProperty?.region}</td>
+            <td class="region">${fastProperty?.region}</td>
             <td class="app"><g:linkObject type="application" name="${fastProperty?.appId?.toLowerCase()}">${fastProperty?.appId}</g:linkObject></td>
             <td class="var">${fastProperty?.stack?.encodeAsHTML()}</td>
             <td class="var">${fastProperty?.countries?.encodeAsHTML()}</td>

--- a/web-app/css/main.css
+++ b/web-app/css/main.css
@@ -206,6 +206,7 @@ th.desc a                   { background-image: url(../images/skin/sorted_desc.g
 .list .fastProperties .var            { max-width:  60px; word-wrap: break-word; white-space: normal; }
 .list .fastProperties .propKey        { max-width: 400px; word-wrap: break-word; }
 .list .fastProperties .propValue      { max-width: 200px; word-wrap: break-word; }
+.list .fastProperties .region         { max-width:  90px; word-wrap: break-word; }
 .list .fastProperties .stack          { max-width:  80px; word-wrap: break-word; }
 .list .fastProperties .updatedBy      { max-width:  80px; word-wrap: break-word; }
 .list .fastProperties .sourceOfUpdate { max-width:  50px; word-wrap: break-word; }


### PR DESCRIPTION
This reduces the risk of people accidentally clicking on the
application link and deleting the application when they meant
to delete a fast property.

Also, protect the list layout from region values that are very long
by applying a max width to the region column.
