### PR TITLE
ASGARD-968 - Do not send system emails if app disappears

### DIFF
--- a/grails-app/services/com/netflix/asgard/ApplicationService.groovy
+++ b/grails-app/services/com/netflix/asgard/ApplicationService.groovy
@@ -177,7 +177,7 @@ class ApplicationService implements CacheInitializer, InitializingBean {
 
     /**
      * Get the email address of the relevant app, or empty string if no email address can be found for the specified
-     * appl name.
+     * app name.
      *
      * @param appName the name of the app that has the email address
      * @return the email address associated with the app, or empty string if no email address can be found


### PR DESCRIPTION
There is an old idea that asgard administrators
should receive task completion emails for applications
that are missing email addresses or applications that
no longer exist in the database. The idea was that
asgard admins could then track down the faulty
applications or functionality and help straighten out
the problem. However, that is no longer practical at
our current large scale, so this system is just adding
useless spam to the AsgardDevelopment email
address.
