### PR TITLE
Update the local stale copy of instance types html

### DIFF
--- a/src/groovy/com/netflix/asgard/mock/instance-types.html
+++ b/src/groovy/com/netflix/asgard/mock/instance-types.html
@@ -1,45 +1,46 @@
+
+
+
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
-  <html>
+<html>
 
-  <head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<link rel="icon" type="image/ico" href="//d36cz9buwru1tt.cloudfront.net/favicon.ico">
-<link rel="shortcut icon" type="image/ico" href="//d36cz9buwru1tt.cloudfront.net/favicon.ico">
-<meta name="description" content="Amazon Elastic Compute Cloud (Amazon EC2) provides the flexibility to choose from a number of different instance types to meet your computing needs. Each instance provides a predictable amount of dedicated compute capacity and is charged per instance-hour consumed." /><meta name="keywords" content="" />
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <link rel="icon" type="image/ico" href="//d36cz9buwru1tt.cloudfront.net/favicon.ico">
+    <link rel="shortcut icon" type="image/ico" href="//d36cz9buwru1tt.cloudfront.net/favicon.ico">
+    <meta name="description" content="Amazon Elastic Compute Cloud (Amazon EC2) provides the flexibility to choose from a number of different instance types to meet your computing needs. Each instance provides a predictable amount of dedicated compute capacity and is charged per instance-hour consumed." /><meta name="keywords" content="" />
 
-<title>Amazon EC2 Instance Types</title>
-
-
-
-<link rel="stylesheet" href="/css/screen_2.css" type="text/css" />
-<!--[if lt IE 9]>
-  <link rel="stylesheet" href="/css/awsGlobalNav3-ltIE9.css" type="text/css" />
-<![endif]-->
-<!--[if lt IE 8]>
-  <link rel="stylesheet" href="/css/awsGlobalNav3-ltIE8.css" type="text/css" />
-<![endif]-->
-<!--[if lt IE 7]>
-  <link rel="stylesheet" href="/css/awsGlobalNav3-ltIE7.css" type="text/css" />
-  <link rel="stylesheet" href="/css/documentationIE6.css" type="text/css" />
-<![endif]-->
+    <title>Amazon EC2 Instance Types</title>
 
 
 
-<script src="/js/all_2.js" type="text/javascript"></script>
-
-<script type="text/javascript">
-__amznUtmPage = "/ec2/instance-types/";
-  </script>
-  <script src="/js/amznUrchin.js" type="text/javascript"></script>
-  </head>
-
-  <body id="top" class="yui-skin-sam noJS">
-
-<!-- layout _210_left -->
-<div id="doc4" class="yui-t2">
-  <div id="hd">
+    <link rel="stylesheet" href="/css/screen_2.css" type="text/css" />
+    <!--[if lt IE 9]>
+    <link rel="stylesheet" href="/css/awsGlobalNav3-ltIE9.css" type="text/css" />
+    <![endif]-->
+    <!--[if lt IE 8]>
+    <link rel="stylesheet" href="/css/awsGlobalNav3-ltIE8.css" type="text/css" />
+    <![endif]-->
+    <!--[if lt IE 7]>
+    <link rel="stylesheet" href="/css/awsGlobalNav3-ltIE7.css" type="text/css" />
+    <link rel="stylesheet" href="/css/documentationIE6.css" type="text/css" />
+    <![endif]-->
 
 
+
+    <script src="/js/all_2.js" type="text/javascript"></script>
+
+    <script type="text/javascript">
+        __amznUtmPage = "/ec2/instance-types/";
+    </script>
+    <script src="/js/amznUrchin.js" type="text/javascript"></script>
+</head>
+
+<body id="top" class="yui-skin-sam noJS">
+
+    <!-- layout _210_left -->
+    <div id="doc4" class="yui-t2">
+        <div id="hd">
 
 
 
@@ -48,984 +49,1051 @@ __amznUtmPage = "/ec2/instance-types/";
 
 
 
-<!-- header -->
-  <div id="main-nav" class="nav-lang-en">
-<a href="//aws.amazon.com/" id="nav-aws-logo" class="nav-sprite" title="Amazon Web Services"><span>Amazon Web Services</span></a>
 
-<div id="nav-bar" class="nav-sprite">
-  <a id="nav-dd-products-solutions" class="nav-link" href="//aws.amazon.com/products-solutions/">
-    <strong>AWS Products</strong> &amp; <strong>Solutions</strong>
-  </a>
 
-  <form id="nav-search-form" method="get" action="//aws.amazon.com/search">
-    <div id="nav-searchfield-outer" class="nav-sprite">
-      <div id="nav-searchfield-inner" class="nav-sprite">
-        <div id="nav-searchfield-width">
-          <input id="nav-searchfield" name="searchQuery"></input>
+
+
+            <!-- header -->
+            <div id="main-nav" class="nav-lang-en">
+                <a href="//aws.amazon.com/" id="nav-aws-logo" class="nav-sprite" title="Amazon Web Services"><span>Amazon Web Services</span></a>
+
+                <div id="nav-bar" class="nav-sprite">
+                    <a id="nav-dd-products-solutions" class="nav-link" href="//aws.amazon.com/products-solutions/">
+                        <strong>AWS Products</strong> &amp; <strong>Solutions</strong>
+                    </a>
+
+                    <form id="nav-search-form" method="get" action="//aws.amazon.com/search">
+                        <div id="nav-searchfield-outer" class="nav-sprite">
+                            <div id="nav-searchfield-inner" class="nav-sprite">
+                                <div id="nav-searchfield-width">
+                                    <input id="nav-searchfield" name="searchQuery"></input>
+                                </div>
+                            </div>
+                        </div>
+
+      <span id="nav-search-in" class="nav-sprite">
+        <span id="nav-search-in-content">Search In</span>
+        <span class="nav-down-arrow nav-sprite"></span>
+        <select name="searchPath" id="nav-search-dropdown"></select>
+      </span>
+
+                        <div id="nav-search-button" class="nav-sprite">
+                            <input type="image" alt="Search" id="nav-search-button-inner" title="Search" src="//d36cz9buwru1tt.cloudfront.net/nav/transparent_pixel.gif">
+                        </div>
+                    </form>
+
+                    <a id="nav-dd-developers" class="nav-link" href="//aws.amazon.com/developers/">
+                        <strong>Developers</strong>
+                    </a>
+
+                    <a id="nav-dd-support" class="nav-link" href="//aws.amazon.com/support/">
+                        <strong>Support</strong>
+                    </a>
+                </div>
+
+                <div id="global-top-links">
+                    <a href="https://aws-portal.amazon.com/gp/aws/developer/registration/index.html" id="gtl-sign-up">Sign Up</a>
+                    <a href="https://console.aws.amazon.com/s3/home" id="gtl-dd-account-console">My Account / Console</a>
+                </div>
+            </div>
+
+
+
+            <noscript>
+                <!--#if expr="${LANG_NOT_FOUND}" -->
+                <div id="pageNotTranslated">
+                    <!--#include virtual="/errors/untranslated/$LANG_NOT_FOUND/index.html" -->
+                </div>
+                <!--#endif -->
+            </noscript>
+
+
+            <script type="text/javascript">
+                if ( ! window.AWSGlobalNav ) {
+                    AWSGlobalNav = {};
+                }
+
+                // This has to be set early (before the onload handlers execute)
+                AWSGlobalNav.acceptLanguage = '<!--#echo var="ACCEPT_LANGUAGE_HEADER" -->';
+                AWSGlobalNav.contentBaseURL = '//aws.amazon.com';
+            </script>
+
+            <!-- /header -->
+
+
         </div>
-      </div>
+        <div id="bd">
+            <!-- layout product_detail -->
+            <div id="yui-main" style="line-height:1.5em;">
+                <div class="yui-b">
+                    <h1 class="title">Amazon EC2 Instance Types</h1>
+
+                    <p><a href="/ec2" title="Amazon EC2">Amazon Elastic Compute Cloud (Amazon EC2)</a> provides the flexibility to choose from a number of different instance types to meet your computing needs. Each instance provides a predictable amount of dedicated compute capacity and is charged per instance-hour consumed.</p>
+
+
+                    <h1>Available Instance Types</h1>
+
+                    <a name="std-instances"></a>
+                    <h3>Standard Instances<br><br></h3>
+
+                    <p style="padding-left:2em;">Instances of this family are well suited for most applications.</p>
+
+
+                    <p style="padding-left:2em;"><strong>Small Instance</strong> &#8211; default<code>++</code></p>
+
+
+                    <p style="padding-left:4em;">1.7 GB memory<br>
+                        1 EC2 Compute Unit (1 virtual core with 1 EC2 Compute Unit)<br>
+                        160 GB instance storage<br>
+                        32-bit or 64-bit platform<br>
+                        I/O Performance: Moderate<br>
+                        EBS-Optimized Available: No<br>
+                        API name: m1.small</p>
+
+                    <p style="padding-left:2em;"><strong>Medium Instance</strong></code></p>
+
+
+                    <p style="padding-left:4em;">3.75 GB memory<br>
+                        2 EC2 Compute Unit (1 virtual core with 2 EC2 Compute Unit)<br>
+                        410 GB instance storage<br>
+                        32-bit or 64-bit platform<br>
+                        I/O Performance: Moderate<br>
+                        EBS-Optimized Available: No<br>
+                        API name: m1.medium</p>
+
+
+                    <p style="padding-left:2em;"><strong>Large Instance</strong></p>
+
+
+                    <p style="padding-left:4em;">7.5 GB memory<br>
+                        4 EC2 Compute Units (2 virtual cores with 2 EC2 Compute Units each)<br>
+                        850 GB instance storage<br>
+                        64-bit platform<br>
+                        I/O Performance: High<br>
+                        EBS-Optimized Available: 500 Mbps<br>
+                        API name: m1.large</p>
+
+
+                    <p style="padding-left:2em;"><strong>Extra Large Instance</strong></p>
+
+
+                    <p style="padding-left:4em;">15 GB memory<br>
+                        8 EC2 Compute Units (4 virtual cores with 2 EC2 Compute Units each)<br>
+                        1,690 GB instance storage<br>
+                        64-bit platform<br>
+                        I/O Performance: High<br>
+                        EBS-Optimized Available: 1000 Mbps<br>
+                        API name: m1.xlarge</p>
+
+                    <a name="micro-instances"></a>
+                    <h3>Micro Instances<br><br></h3>
+
+
+                    <p style="padding-left:2em;">Micro instances (t1.micro) provide a small amount of consistent CPU resources and allow you to increase CPU capacity in short bursts when additional cycles are available.  They are well suited for lower throughput applications and web sites that require additional compute cycles periodically.  You can learn more about how you can use Micro instances and appropriate applications in the <a href="http://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/concepts_micro_instances.html">Amazon EC2 documentation</a></p>
+
+
+                    <p style="padding-left:2em;"><strong>Micro Instance</strong></p>
+
+
+                    <p style="padding-left:4em;">613 MB memory<br>
+                        Up to 2 EC2 Compute Units (for short periodic bursts)<br>
+                        EBS storage only<br>
+                        32-bit or 64-bit platform<br>
+                        I/O Performance: Low<br>
+                        EBS-Optimized Available: No<br>
+                        API name: t1.micro<br></p>
+
+                    <a name="himem-instances"></a>
+                    <h3>High-Memory Instances<br><br></h3>
+
+                    <p style="padding-left:2em;">Instances of this family offer large memory sizes for high throughput applications, including database and memory caching applications.</p>
+
+
+                    <p style="padding-left:2em;"><strong>High-Memory Extra Large Instance</strong></p>
+
+
+                    <p style="padding-left:4em;">17.1 GB of memory<br>
+                        6.5 EC2 Compute Units (2 virtual cores with 3.25 EC2 Compute Units each)<br>
+                        420 GB of instance storage<br>
+                        64-bit platform<br>
+                        I/O Performance: Moderate<br>
+                        EBS-Optimized Available: No<br>
+                        API name: m2.xlarge<br></p>
+
+
+                    <p style="padding-left:2em;"><strong>High-Memory Double Extra Large Instance</strong></p>
+
+
+                    <p style="padding-left:4em;">34.2 GB of memory<br>
+                        13 EC2 Compute Units (4 virtual cores with 3.25 EC2 Compute Units each)<br>
+                        850 GB of instance storage<br>
+                        64-bit platform<br>
+                        I/O Performance: High<br>
+                        EBS-Optimized Available: No<br>
+                        API name: m2.2xlarge<br></p>
+
+
+                    <p style="padding-left:2em;"><strong>High-Memory Quadruple Extra Large Instance</strong></p>
+
+
+                    <p style="padding-left:4em;">68.4 GB of memory<br>
+                        26 EC2 Compute Units (8 virtual cores with 3.25 EC2 Compute Units each)<br>
+                        1690 GB of instance storage<br>
+                        64-bit platform<br>
+                        I/O Performance: High<br>
+                        EBS-Optimized Available: 1000 Mbps<br>
+                        API name: m2.4xlarge<br></p>
+
+                    <a name="std-instances"></a>
+                    <h3>High-CPU Instances<br><br></h3>
+
+
+                    <p style="padding-left:2em;">Instances of this family have proportionally more CPU resources than memory (RAM) and are well suited for compute-intensive applications.</p>
+
+
+                    <p style="padding-left:2em;"><strong>High-CPU Medium Instance</strong></p>
+
+
+                    <p style="padding-left:4em;">1.7 GB of memory<br>
+                        5 EC2 Compute Units (2 virtual cores with 2.5 EC2 Compute Units each)<br>
+                        350 GB of instance storage<br>
+                        32-bit or 64-bit platform<br>
+                        I/O Performance: Moderate<br>
+                        EBS-Optimized Available: No<br>
+                        API name: c1.medium<br></p>
+
+
+                    <p style="padding-left:2em;"><strong>High-CPU Extra Large Instance</strong></p>
+
+
+                    <p style="padding-left:4em;">7 GB of memory<br>
+                        20 EC2 Compute Units (8 virtual cores with 2.5 EC2 Compute Units each)<br>
+                        1690 GB of instance storage<br>
+                        64-bit platform<br>
+                        I/O Performance: High<br>
+                        EBS-Optimized Available: No<br>
+                        API name: c1.xlarge<br></p>
+
+                    <a name="clustercompute-instances"></a>
+                    <h3>Cluster Compute Instances<br><br></h3>
+
+
+                    <p style="padding-left:2em;">Instances of this family provide proportionally high CPU resources with increased network performance and are well suited for High Performance Compute (HPC) applications and other demanding network-bound applications. You can learn more about Cluster instance concepts by reading the <a href="http://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/using_cluster_computing.html">Amazon EC2 documentation</a>. For more information about specific use cases and cluster management options for HPC, please visit the <a href="http://aws.amazon.com/ec2/hpc-applications/">HPC solutions page</a>.</p>
+
+
+                    <p style="padding-left:2em;"><strong>Cluster Compute Quadruple Extra Large Instance</strong></p>
+
+
+                    <p style="padding-left:4em;">23 GB of memory<br>
+                        33.5 EC2 Compute Units (2 x Intel Xeon X5570, quad-core &#8220;Nehalem&#8221; architecture)<br>
+                        1690 GB of instance storage<br>
+                        64-bit platform<br>
+                        I/O Performance: Very High (10 Gigabit Ethernet)<br>
+                        EBS-Optimized Available: No*<br>
+                        API name: cc1.4xlarge<br></p>
+
+                    <p style="padding-left:2em;">*Cluster Compute, Cluster GPU and High I/O instances do not currently support EBS Optimization, but provide customers with high bandwidth networking and can also be used with EBS Provisioned IOPS volumes for improved consistency and performance.</p>
+
+                    <p style="padding-left:2em;"><strong>Cluster Compute Eight Extra Large Instance</strong></p>
+
+
+                    <p style="padding-left:4em;">60.5 GB of memory<br>
+                        88 EC2 Compute Units (2 x Intel Xeon E5-2670, eight-core "Sandy Bridge" architecture)<br>
+                        3370 GB of instance storage<br>
+                        64-bit platform<br>
+                        I/O Performance: Very High (10 Gigabit Ethernet)<br>
+                        EBS-Optimized Available: No*<br>
+                        API name: cc2.8xlarge<br></p>
+
+                    <p style="padding-left:2em;">*Cluster Compute, Cluster GPU and High I/O instances do not currently support EBS Optimization, but provide customers with high bandwidth networking and can also be used with EBS Provisioned IOPS volumes for improved consistency and performance.</p>
+
+                    <a name="clustergpu-instances"></a>
+                    <h3>Cluster GPU Instances<br><br></h3>
+
+
+                    <p style="padding-left:2em;">Instances of this family provide general-purpose graphics processing units (GPUs) with proportionally high CPU and increased network performance for applications benefitting from highly parallelized processing, including HPC, rendering and media processing applications. While Cluster Compute Instances provide the ability to create clusters of instances connected by a low latency, high throughput network, Cluster GPU Instances provide an additional option for applications that can benefit from the efficiency gains of the parallel computing power of GPUs over what can be achieved with traditional processors. <a href="http://aws.amazon.com/ec2/hpc-applications/">Learn more</a> about use of this instance type for HPC applications.</p>
+
+
+                    <p style="padding-left:2em;"><strong>Cluster GPU Quadruple Extra Large Instance</strong></p>
+
+
+                    <p style="padding-left:4em;">22 GB of memory<br>
+                        33.5 EC2 Compute Units (2 x Intel Xeon X5570, quad-core &#8220;Nehalem&#8221; architecture)<br>
+                        2 x NVIDIA Tesla “Fermi” M2050 GPUs<br>
+                        1690 GB of instance storage<br>
+                        64-bit platform<br>
+                        I/O Performance: Very High (10 Gigabit Ethernet)<br>
+                        EBS-Optimized Available: No*<br>
+                        API name: cg1.4xlarge<br></p>
+
+                    <p style="padding-left:2em;">*Cluster Compute, Cluster GPU and High I/O instances do not currently support EBS Optimization, but provide customers with high bandwidth networking and can also be used with EBS Provisioned IOPS volumes for improved consistency and performance.</p>
+
+                    <a name="highio-instances"></a>
+                    <h3>High I/O Instances<br><br></h3>
+
+
+                    <p style="padding-left:2em;">Instances of this family provide very high instance storage I/O performance and are ideally suited for many high performance database workloads.  Example applications include NoSQL databases like Cassandra and MongoDB. High I/O instances are backed by Solid State Drives (SSD), and also provide high levels of CPU, memory and network performance.</p>
+
+                    <p style="padding-left:2em;"><strong>High I/O Quadruple Extra Large Instance</strong></p>
+
+
+                    <p style="padding-left:4em;">60.5 GB of memory<br>
+                        35 EC2 Compute Units (16 virtual cores*)<br>
+                        2 SSD-based volumes each with 1024 GB of instance storage<br>
+                        64-bit platform<br>
+                        I/O Performance: Very High (10 Gigabit Ethernet)<br>
+                        Storage I/O Performance: Very High**<br>
+                        EBS-Optimized Available: No***<br>
+                        API name: hi1.4xlarge<br></p>
+
+                    <p style="padding-left:2em;">*8 cores + 8 hyperthreads for 16 virtual cores
+                        <br>
+                        <br>
+                        **Using Linux paravirtual (PV) AMIs, High I/O Quadruple Extra Large instances can deliver more than 120,000 4 KB random read IOPS and between 10,000 and 85,000 4 KB random write IOPS (depending on active logical block addressing span) to applications. For hardware virtual machines (HVM) and Windows AMIs, performance is approximately 90,000 4 KB random read IOPS and between 9,000 and 75,000 4 KB random write IOPS.  The maximum sequential throughput on all AMI types (Linux PV, Linux HVM, and Windows) per second is approximately 2 GB read and 1.1 GB write.
+                        <br>
+                        <br>
+                        For customers using Microsoft Windows Server, High I/O Instances are only supported with the Microsoft Windows Server AMIs for Cluster Instance Type.</p>
+
+                    <p style="padding-left:2em;">***Cluster Compute, Cluster GPU and High I/O instances do not currently support EBS Optimization, but provide customers with high bandwidth networking and can also be used with EBS Provisioned IOPS volumes for improved consistency and performance.</p>
+
+                    <h1>EBS-Optimized Instances</h1>
+
+                    <p>For a low, additional, hourly fee, customers can launch selected Amazon EC2 instances types as “EBS-Optimized” instances.  EBS-Optimized instances enable Amazon EC2 instances to fully utilize the IOPS provisioned on an EBS volume.  EBS-optimized instances deliver dedicated throughput between Amazon EC2 and Amazon EBS, with options between 500 Mbps and 1000 Mbps depending on the instance type used.  When attached to EBS-Optimized instances, Provisioned IOPS volumes are designed to deliver within 10% of their provisioned performance 99.9% of the time. See <a href="/ec2/instance-types">Amazon EC2 Instance Types</a> to find out more about instance types that can be launched as EBS-optimized instances.</p>
+
+
+
+                    <h1>Selecting Instance Types</h1>
+
+
+                    <p>Amazon EC2 instances are grouped into seven families: Standard, Micro, High-Memory, High-CPU, Cluster Compute, Cluster GPU, and High I/O.</p>
+
+
+                    <p>Standard Instances have memory to CPU ratios suitable for most general purpose applications; High-Memory instances offer larger memory sizes for high throughput applications, including database and memory caching applications; and High-CPU instances have proportionally more CPU resources than memory (RAM) and are well suited for compute-intensive applications.</p>
+
+
+                    <p>Micro instances provide a small amount of consistent CPU resources and allow you to burst CPU capacity when additional cycles are available. They are well suited for lower throughput applications and web sites that consume significant compute cycles periodically.  At steady state, Micro instances receive a fraction of the compute resources that Small instances do. Therefore, if your application has compute-intensive or steady state needs we recommend using a Small instance (or larger, depending on your needs).  However, Micro instances can periodically burst up to 2 ECUs (for short periods of time). This is double the number of ECUs available from a Standard Small instance. Therefore, if you have a relatively low throughput application or web site with an occasional need to consume significant compute cycles, we recommend using Micro instances.</p>
+
+
+                    <p>Cluster Compute instances provide a very large amount of CPU coupled with increased network performance making them well suited for High Performance Compute (HPC) applications and other demanding network-bound applications.</p>
+
+
+                    <p>Cluster GPU instances provide general-purpose graphics processing units (GPUs) with proportionally high CPU and increased network performance making them well suited for applications benefitting from highly parallelized processing, including HPC, rendering and media processing applications.</p>
+
+                    <p>High I/O instances take advantage of Solid State Disk (SSD) technology to provide a very large amount of random I/O performance.  High I/O instances are ideal for applications that benefit a large number of low latency IOPS such as NoSQL databases and relational databases.</p>
+
+                    <p>Customers running databases should consider launching instances as EBS-Optimized instances. The combination of EBS-Optimized instances and Amazon EBS Provisioned IOPS volumes ensures that instances are capable of consistent EBS I/O performance.</p>
+
+                    <p>When choosing instance types, you should consider the characteristics of your application with regards to resource utilization and select the optimal instance family and size. One of the advantages of EC2 is that you pay by the instance hour, which makes it convenient and inexpensive to test the performance of your application on different instance families and types. One good way to determine the most appropriate instance family and instance type is to launch test instances and benchmark your application.</p>
+
+
+                    <h1>Measuring Compute Resources</h1>
+
+
+                    <p>Transitioning to a utility computing model fundamentally changes how developers have been trained to think about CPU resources.  Instead of purchasing or leasing a particular processor to use for several months or years, you are renting capacity by the hour.  Because Amazon EC2 is built on commodity hardware, over time there may be several different types of physical hardware underlying EC2 instances.  Our goal is to provide a consistent amount of CPU capacity no matter what the actual underlying hardware.</p>
+
+
+                    <p>Amazon EC2 uses a variety of measures to provide each instance with a consistent and predictable amount of CPU capacity.  In order to make it easy for developers to compare CPU capacity between different instance types, we have defined an Amazon EC2 Compute Unit.  The amount of CPU that is allocated to a particular instance is expressed in terms of these EC2 Compute Units. We use several benchmarks and tests to manage the consistency and predictability of the performance of an EC2 Compute Unit. One EC2 Compute Unit provides the equivalent CPU capacity of a 1.0-1.2 GHz 2007 Opteron or 2007 Xeon processor. This is also the equivalent to an early-2006 1.7 GHz Xeon processor referenced in our original documentation. Over time, we may add or substitute measures that go into the definition of an EC2 Compute Unit, if we find metrics that will give you a clearer picture of compute capacity.</p>
+
+
+                    <p>To find out which instance will work best for your application, the best thing to do is to launch an instance and benchmark your own application.  One of the advantages of EC2 is that you pay by the hour which makes it convenient and inexpensive to test the performance of your application on different instance types.</p>
+
+
+                    <h1>I/O Performance</h1>
+
+
+                    <p>Amazon EC2 provides virtualized server instances. While some resources like CPU, memory and instance storage are dedicated to a particular instance, other resources like the network and the disk subsystem are shared among instances.  If each instance on a physical host tries to use as much of one of these shared resources as possible, each will receive an equal share of that resource. However, when a resource is under-utilized you will often be able to consume a higher share of that resource while it is available.</p>
+
+
+                    <p>The different instance types will provide higher or lower minimum performance from the shared resources depending on their size.  Each of the instance types has an I/O performance indicator (<em>low</em>, <em>moderate</em>, or <em>high</em>). Instance types with high I/O performance have a larger allocation of shared resources. Allocating larger share of shared resources also reduces the variance of I/O performance. For many applications, <em>low</em> or <em>moderate</em> I/O performance is more than enough.  However, for those applications requiring greater or more consistent I/O performance, you may want to consider instances with <em>high</em> I/O performance.</p>
+
+
+                    <p>Cluster Compute and Cluster GPU instances have <em>very high</em> I/O performance using 10 Gigabit Ethernet for high throughput and reduced network latencies within clusters.</p>
+
+
+                    <p>High I/O Instances are designed to provide customers with a very high amount of low latency storage I/O by taking advantage of direct attached, SSD-backed storage volumes.  High I/O instances can deliver in excess of 100,000 random read IOPS and as many as 80,000 random write IOPS for high performance NoSQL and relationsal database applications.  In addition to storage performance, High I/O instances also have very high I/O performance via 10 Gigabit Ethernet for high throughput and reduced network latencies within clusters.</p>
+
+                    <p>In addition, you can use Amazon EBS to get improved storage I/O performance for disk-bound applications. Amazon EBS standard volumes provide customers with reliable, low cost, persistent storage, and customers can scale I/O performance by striping across many EBS volumes.  Amazon EBS Provisioned IOPS volumes allow customers to provision the desired level of storage volume performance and should be used with Amazon EC2 EBS-Optimized instances to maximize I/O performance and consistency. EBS-Optimized instances provide customers with an optimized configuration and dedicated throughput for consistency of EBS I/O performance.</p>
+
+
+                    <p><br>
+                    <hr/>
+                    <br></p>
+
+
+                    <p>++The Small Instance type is equivalent to the original Amazon EC2 instance type that has been available since Amazon EC2 launched. This instance type is currently the default for all customers. To use other instance types, customers must specifically request them via the <em>RunInstances</em> API.</p>
+                </div>
+            </div>
+
+
+            <div class="yui-b">
+                <div id="sideNav">
+
+
+
+
+
+
+
+
+
+
+
+
+
+                    <div id="subNavA">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                        <div id="subPageSelector" class="products">
+                            <div id="subPageComboButton"></div>
+                            <div class="flyout">
+                                <div class="liner">
+
+                                    <div class="col1">
+                                        <h4>Compute</h4>
+                                        <ul class="">
+
+
+                                            <li class="">
+                                                <a href="/ec2/" class="">
+                                                    Amazon Elastic Compute Cloud <span class="norm">(EC2)</span>
+                                                </a>
+                                            </li>
+
+
+                                            <li class="">
+                                                <a href="/elasticmapreduce/" class="">
+                                                    Amazon Elastic MapReduce
+                                                </a>
+                                            </li>
+
+
+                                            <li class="">
+                                                <a href="/autoscaling/" class="">
+                                                    Auto Scaling
+                                                </a>
+                                            </li>
+
+
+                                        </ul>
+
+                                        <h4>Content Delivery</h4>
+                                        <ul class="">
+
+
+                                            <li class="">
+                                                <a href="/cloudfront/" class="">
+                                                    Amazon CloudFront
+                                                </a>
+                                            </li>
+
+
+                                        </ul>
+
+                                        <h4>Database</h4>
+                                        <ul class="">
+
+
+                                            <li class="">
+                                                <a href="/rds/" class="">
+                                                    Amazon Relational Database Service <span class="norm">(RDS)</span>
+                                                </a>
+                                            </li>
+
+
+                                            <li class="">
+                                                <a href="/dynamodb/" class="">
+                                                    Amazon DynamoDB</span>
+                                                </a>
+                                            </li>
+
+
+                                            <li class="">
+                                                <a href="/simpledb/" class="">
+                                                    Amazon SimpleDB
+                                                </a>
+                                            </li>
+
+
+                                            <li class="">
+                                                <a href="/elasticache/" class="">
+                                                    Amazon ElastiCache </span>
+                                                </a>
+                                            </li>
+
+
+                                        </ul>
+
+                                        <h4>Deployment & Management</h4>
+                                        <ul class="">
+
+
+                                            <li class="">
+                                                <a href="/elasticbeanstalk/" class="">
+                                                    AWS Elastic Beanstalk
+                                                </a>
+                                            </li>
+
+
+                                            <li class="">
+                                                <a href="/cloudformation/" class="">
+                                                    AWS CloudFormation
+                                                </a>
+                                            </li>
+
+
+                                        </ul>
+
+                                        <h4>E-Commerce</h4>
+                                        <ul class="">
+
+
+                                            <li class="">
+                                                <a href="/fws/" class="">
+                                                    Amazon Fulfillment Web Service (FWS)
+                                                </a>
+                                            </li>
+
+
+                                        </ul>
+
+                                        <h4>Industry-specific Clouds</h4>
+                                        <ul class="">
+
+
+                                            <li class="">
+                                                <a href="/govcloud-us/" class="">
+                                                    AWS GovCloud (US)
+                                                </a>
+                                            </li>
+
+
+                                        </ul>
+
+                                        <h4>Messaging</h4>
+                                        <ul class="">
+
+
+                                            <li class="">
+                                                <a href="/sqs/" class="">
+                                                    Amazon Simple Queue Service <span class="norm">(SQS)</span>
+                                                </a>
+                                            </li>
+
+
+                                            <li class="">
+                                                <a href="/sns/" class="">
+                                                    Amazon Simple   Notification Service <span class="norm">(SNS)</span>
+                                                </a>
+                                            </li>
+
+
+                                            <li class="">
+                                                <a href="/ses/" class="">
+                                                    Amazon Simple Email Service <span class="norm">(SES)</span>
+                                                </a>
+                                            </li>
+
+
+                                        </ul>
+
+                                        <h4>Monitoring</h4>
+                                        <ul class="">
+
+
+                                            <li class="">
+                                                <a href="/cloudwatch/" class="">
+                                                    Amazon CloudWatch
+                                                </a>
+                                            </li>
+
+
+                                        </ul>
+                                    </div>
+
+                                    <div class="col2">
+                                        <h4>Networking</h4>
+                                        <ul class="">
+
+
+                                            <li class="">
+                                                <a href="/route53/" class="">
+                                                    Amazon Route 53
+                                                </a>
+                                            </li>
+
+
+                                            <li class="">
+                                                <a href="/vpc/" class="">
+                                                    Amazon Virtual Private Cloud <span class="norm">(VPC)</span>
+                                                </a>
+                                            </li>
+
+
+                                            <li class="">
+                                                <a href="/elasticloadbalancing/" class="">
+                                                    Elastic Load Balancing
+                                                </a>
+                                            </li>
+
+
+                                            <li class="">
+                                                <a href="/directconnect/" class="">
+                                                    AWS Direct Connect
+                                                </a>
+                                            </li>
+
+
+                                        </ul>
+
+                                        <h4>Payments &amp; Billing</h4>
+                                        <ul class="">
+
+
+                                            <li class="">
+                                                <a href="/fps/" class="">
+                                                    Amazon Flexible Payments Service <span class="norm">(FPS)</span>
+                                                </a>
+                                            </li>
+
+
+                                            <li class="">
+                                                <a href="/devpay/" class="">
+                                                    Amazon DevPay
+                                                </a>
+                                            </li>
+
+
+                                        </ul>
+
+                                        <h4>Storage</h4>
+                                        <ul class="">
+
+
+                                            <li class="">
+                                                <a href="/s3/" class="">
+                                                    Amazon Simple Storage Service <span class="norm">(S3)</span>
+                                                </a>
+                                            </li>
+
+
+                                            <li class="">
+                                                <a href="/ebs/" class="">
+                                                    Amazon Elastic Block Store <span class="norm">(EBS)</span>
+                                                </a>
+                                            </li>
+
+
+                                            <li class="">
+                                                <a href="/importexport/" class="">
+                                                    AWS Import/Export
+                                                </a>
+                                            </li>
+
+
+                                        </ul>
+
+                                        <h4>Support</h4>
+                                        <ul class="">
+
+
+                                            <li class="">
+                                                <a href="/premiumsupport/" class="">
+                                                    AWS Premium Support
+                                                </a>
+                                            </li>
+
+
+                                        </ul>
+
+                                        <h4>Web Traffic</h4>
+                                        <ul class="">
+
+
+                                            <li class="">
+                                                <a href="/awis/" class="">Alexa Web Information Service</a>
+                                            </li>
+
+
+                                            <li class="">
+                                                <a href="/alexatopsites/" class="">Alexa Top Sites</a>
+                                            </li>
+
+
+                                        </ul>
+
+                                        <h4>Workforce</h4>
+                                        <ul class="">
+
+
+                                            <li class="">
+                                                <a href="/mturk/" class="">
+                                                    Amazon Mechanical Turk
+                                                </a>
+                                            </li>
+
+
+                                        </ul>
+                                    </div>
+
+
+                                </div>
+                            </div>
+                            <a href="/products/" class="noScript">Products &amp; Services</a>
+                        </div>
+
+
+
+
+
+                        <div class="decoratedBox ">
+                            <div class="head">
+                                <h4>Amazon EC2 Details</h4>
+                            </div>
+                            <div class="body">
+                                <div class="liner">
+
+                                    <ul class="">
+
+
+                                        <li class="">
+                                            <a href="/ec2/" class="">EC2 Overview</a>
+                                        </li>
+
+
+                                        <li class="">
+                                            <a href="/ec2/faqs/" class="">EC2 FAQs</a>
+                                        </li>
+
+
+                                        <li class="">
+                                            <a href="/ec2/pricing/" class="">EC2 Pricing</a>
+                                        </li>
+
+
+                                        <li class="">
+                                            <a href="/ec2-sla/" class="">Amazon EC2 SLA</a>
+                                        </li>
+
+
+                                        <li class="">
+                                            <a href="/ec2/instance-types/" class="selected">EC2 Instance Types</a>
+                                        </li>
+
+
+                                        <li class="">
+                                            <a href="/ec2/purchasing-options/" class="">EC2 Instance Purchasing Options</a>
+                                        </li>
+
+
+                                        <li class="">
+                                            <a href="/ec2/reserved-instances/" class="">Reserved Instances</a>
+                                        </li>
+
+
+                                        <li class="">
+                                            <a href="/ec2/spot-instances/" class="">Spot Instances</a>
+                                        </li>
+
+
+                                        <li class="last">
+                                            <a href="/windows/" class="">Windows Instances</a>
+                                        </li>
+
+
+                                    </ul>
+
+                                </div>
+                            </div>
+                        </div>
+
+
+
+                        <div class="decoratedBox last">
+                            <div class="head">
+                                <h4>Amazon EC2 Features</h4>
+                            </div>
+                            <div class="body">
+                                <div class="liner">
+
+                                    <ul class="">
+
+
+                                        <li class="">
+                                            <a href="/ebs/" class="">Elastic Block Store</a>
+                                        </li>
+
+
+                                        <li class="">
+                                            <a href="/cloudwatch/" class="">Amazon CloudWatch</a>
+                                        </li>
+
+
+                                        <li class="">
+                                            <a href="/autoscaling/" class="">Auto Scaling</a>
+                                        </li>
+
+
+                                        <li class="">
+                                            <a href="/elasticloadbalancing/" class="">Elastic Load Balancing</a>
+                                        </li>
+
+
+                                        <li class="">
+                                            <a href="/ec2/hpc-applications/" class="">High Performance Computing</a>
+                                        </li>
+
+
+                                        <li class="last">
+                                            <a href="/ec2/vmimport/" class="">VM Import/Export</a>
+                                        </li>
+
+
+                                    </ul>
+
+                                </div>
+                            </div>
+                        </div>
+
+                    </div>
+
+
+                    <div id="subNavB">
+
+                        <div class="decoratedBox ">
+                            <div class="head">
+                                <h4>Related Resources</h4>
+                            </div>
+                            <div class="body">
+                                <div class="liner">
+
+                                    <ul class="">
+
+
+                                        <li class="">
+                                            <a href="/console/" class="">AWS Management Console</a>
+                                        </li>
+
+
+                                        <li class="">
+                                            <a href="/documentation/ec2/" class="">Documentation</a>
+                                        </li>
+
+
+                                        <li class="">
+                                            <a href="http://developer.amazonwebservices.com/connect/kbcategory.jspa?categoryID=86" class="">Release Notes</a>
+                                        </li>
+
+
+                                        <li class="">
+                                            <a href="http://developer.amazonwebservices.com/connect/kbcategory.jspa?categoryID=85" class="">Sample Code & Libraries</a>
+                                        </li>
+
+
+                                        <li class="">
+                                            <a href="http://developer.amazonwebservices.com/connect/kbcategory.jspa?categoryID=88" class="">Developer Tools</a>
+                                        </li>
+
+
+                                        <li class="">
+                                            <a href="http://developer.amazonwebservices.com/connect/kbcategory.jspa?categoryID=100" class="">Articles & Tutorials</a>
+                                        </li>
+
+
+                                        <li class="">
+                                            <a href="http://developer.amazonwebservices.com/connect/kbcategory.jspa?categoryID=171" class="">Amazon Machine Images (AMIs)</a>
+                                        </li>
+
+
+                                        <li class="">
+                                            <a href="/publicdatasets/" class="">Public Data Sets on AWS</a>
+                                        </li>
+
+
+                                        <li class="last">
+                                            <a href="http://developer.amazonwebservices.com/connect/forum.jspa?forumID=30" class="">Community Forum</a>
+                                        </li>
+
+
+                                    </ul>
+
+                                </div>
+                            </div>
+                        </div>
+
+
+                        <br><br><br>
+
+
+                        <div class="decoratedBox last">
+                            <div class="head">
+                                <h4>Want to Save on Your Amazon EC2 Bill?</h4>
+                            </div>
+                            <div class="body">
+                                <div class="liner">
+
+                                    <div class="liner">
+                                        <img src="//d36cz9buwru1tt.cloudfront.net/logo_harvard_sm2.gif"
+                                             width="150px"
+                                             class="logo"
+                                             title="Harvard" alt="Harvard"/>
+                                        <p>
+                                            See how customers like Harvard Medical School significantly reduced their Amazon EC2 bill by using Spot Instances.
+                                        </p>
+                                        <div class="learnMore">
+                                            <span class="carat">&gt;</span>
+                                            <a href="/ec2/spot-instances">Learn More</a>
+                                        </div>
+                                    </div>
+
+                                </div>
+                            </div>
+                        </div>
+
+                        <br><br><br>
+
+                        <div class="decoratedBox ">
+                            <div class="head">
+                                <h4>EC2 Running Microsoft</h4>
+                            </div>
+                            <div class="body">
+                                <div class="liner">
+
+                                    <div class="liner">
+                                        <img src="//d36cz9buwru1tt.cloudfront.net/globalNav/img/logo-microsoft.png"
+                                             width="137"
+                                             height="27"
+                                             class="logo"
+                                             alt="Microsoft"/>
+                                        <p>
+                                            Amazon EC2 running Microsoft Windows Server&reg; 2003/2008 is a fast and
+                                            dependable environment for deploying applications using the Microsoft Web Platform.
+                                        </p>
+                                        <div class="learnMore">
+                                            <span class="carat">&gt;</span>
+                                            <a href="/windows/">Learn More</a>
+                                        </div>
+                                    </div>
+
+                                </div>
+                            </div>
+                        </div>
+
+
+                        <br><br><br>
+
+                        <div class="decoratedBox last">
+                            <div class="head">
+                                <h4>EC2 Running IBM</h4>
+                            </div>
+                            <div class="body">
+                                <div class="liner">
+
+                                    <div class="liner">
+                                        <img src="//d36cz9buwru1tt.cloudfront.net/globalNav/img/logo-ibm.png"
+                                             width="140"
+                                             height="53"
+                                             class="logo"
+                                             alt="IBM"/>
+                                        <p>
+                                            You can run many of the proven IBM platform technologies with which you're already familiar.
+                                        </p>
+                                        <div class="learnMore">
+                                            <span class="carat">&gt;</span>
+                                            <a href="/ibm/">Learn More</a>
+                                        </div>
+                                    </div>
+
+                                </div>
+                            </div>
+                        </div>
+
+
+                        <br><br><br>
+
+                        <div class="decoratedBox last">
+                            <div class="head">
+                                <h4>Amazon EC2 is Hiring!</h4>
+                            </div>
+                            <div class="body">
+                                <div class="liner">
+
+                                    <div class="liner">
+                                        <img src="//d36cz9buwru1tt.cloudfront.net/logo_aws.gif"
+                                             width="140"
+                                             height="53"
+                                             class="logo"
+                                             alt="AWS"/>
+                                        Amazon EC2 is hiring to rapidly expand our service.
+                                        </p>
+                                        <div class="learnMore">
+                                            <span class="carat">&gt;</span>
+                                            <a href="/ec2-jobs/">Learn More</a>
+                                        </div>
+                                    </div>
+
+                                </div>
+                            </div>
+                        </div>
+
+                    </div>
+
+                    <br>
+                    <br>
+
+
+
+                </div>
+            </div>
+
+        </div>
+        <div id="ft">
+
+
+
+
+
+
+
+
+
+
+
+
+            <div style="border-top: 1px solid #ccc; margin-bottom: 12px; margin-top: 10px; padding-top: 2px;">
+                <ul class="h_bar">
+                    <li class="first">
+                        <a href="http://aws.typepad.com/" target="_blank">AWS Blog <img src="//d36cz9buwru1tt.cloudfront.net/icon_offsite.gif" width="15" height="13" border="0" alt="This link will launch a new browser window or tab."></a>
+                    </li>
+                    <li><a href="http://phx.corporate-ir.net/phoenix.zhtml?c=176060&p=irol-InfoReq">Press Inquiries</a></li>
+                    <li><a href="/careers/">Careers at AWS</a></li>
+                    <li><a href="/contact-us/">Contact Us</a></li>
+                    <li><a href="/privacy/">Privacy Policy</a></li>
+                    <li><a href="/terms/">Terms of Use</a></li>
+                </ul>
+                <div class="grey666">&#169;2011, Amazon Web Services LLC or its affiliates. All rights reserved.</div>
+                <img src="//d36cz9buwru1tt.cloudfront.net/awsmedia/logo_an_amazon_company.gif" width="160" height="21" vspace="8">
+            </div>
+
+        </div>
     </div>
 
-    <span id="nav-search-in" class="nav-sprite">
-      <span id="nav-search-in-content">Search In</span>
-      <span class="nav-down-arrow nav-sprite"></span>
-      <select name="searchPath" id="nav-search-dropdown"></select>
-    </span>
 
-    <div id="nav-search-button" class="nav-sprite">
-      <input type="image" alt="Search" id="nav-search-button-inner" title="Search" src="//d36cz9buwru1tt.cloudfront.net/nav/transparent_pixel.gif">
-    </div>
-  </form>
 
-  <a id="nav-dd-developers" class="nav-link" href="//aws.amazon.com/developers/">
-    <strong>Developers</strong>
-  </a>
+</body>
 
-  <a id="nav-dd-support" class="nav-link" href="//aws.amazon.com/support/">
-    <strong>Support</strong>
-  </a>
-</div>
-
-<div id="global-top-links">
-  <a href="https://aws-portal.amazon.com/gp/aws/developer/registration/index.html" id="gtl-sign-up">Sign Up</a>
-  <a href="https://console.aws.amazon.com/s3/home" id="gtl-dd-account-console">My Account / Console</a>
-</div>
-  </div>
-
-
-
-  <noscript>
-<!--#if expr="${LANG_NOT_FOUND}" -->
-  <div id="pageNotTranslated">
-    <!--#include virtual="/errors/untranslated/$LANG_NOT_FOUND/index.html" -->
-  </div>
-<!--#endif -->
-  </noscript>
-
-
-  <script type="text/javascript">
-if ( ! window.AWSGlobalNav ) {
-    AWSGlobalNav = {};
-}
-
-// This has to be set early (before the onload handlers execute)
-AWSGlobalNav.acceptLanguage = '<!--#echo var="ACCEPT_LANGUAGE_HEADER" -->';
-AWSGlobalNav.contentBaseURL = '//aws.amazon.com';
-  </script>
-
-  <!-- /header -->
-
-
-  </div>
-  <div id="bd">
-<!-- layout product_detail -->
-<div id="yui-main" style="line-height:1.5em;">
-  <div class="yui-b">
-    <h1 class="title">Amazon EC2 Instance Types</h1>
-
-  <p><a href="/ec2" title="Amazon EC2">Amazon Elastic Compute Cloud (Amazon EC2)</a> provides the flexibility to choose from a number of different instance types to meet your computing needs. Each instance provides a predictable amount of dedicated compute capacity and is charged per instance-hour consumed.</p>
-
-
-  <h1>Available Instance Types</h1>
-
-     <a name="std-instances"></a>
-  <h3>Standard Instances<br><br></h3>
-
-  <p style="padding-left:2em;">Instances of this family are well suited for most applications.</p>
-
-
-  <p style="padding-left:2em;"><strong>Small Instance</strong> &#8211; default<code>*</code></p>
-
-
-  <p style="padding-left:4em;">1.7 GB memory<br>
-  1 EC2 Compute Unit (1 virtual core with 1 EC2 Compute Unit)<br>
-  160 GB instance storage<br>
-  32-bit or 64-bit platform<br>
-  I/O Performance: Moderate<br>
-  API name: m1.small</p>
-
-  <p style="padding-left:2em;"><strong>Medium Instance</strong></code></p>
-
-
-  <p style="padding-left:4em;">3.75 GB memory<br>
-  2 EC2 Compute Unit (1 virtual core with 2 EC2 Compute Unit)<br>
-  410 GB instance storage<br>
-  32-bit or 64-bit platform<br>
-  I/O Performance: Moderate<br>
-  API name: m1.medium</p>
-
-
-  <p style="padding-left:2em;"><strong>Large Instance</strong></p>
-
-
-  <p style="padding-left:4em;">7.5 GB memory<br>
-  4 EC2 Compute Units (2 virtual cores with 2 EC2 Compute Units each)<br>
-  850 GB instance storage<br>
-  64-bit platform<br>
-  I/O Performance: High<br>
-  API name: m1.large</p>
-
-
-  <p style="padding-left:2em;"><strong>Extra Large Instance</strong></p>
-
-
-  <p style="padding-left:4em;">15 GB memory<br>
-  8 EC2 Compute Units (4 virtual cores with 2 EC2 Compute Units each)<br>
-  1,690 GB instance storage<br>
-  64-bit platform<br>
-  I/O Performance: High<br>
-  API name: m1.xlarge</p>
-
-  <a name="micro-instances"></a>
-  <h3>Micro Instances<br><br></h3>
-
-
-  <p style="padding-left:2em;">Micro instances (t1.micro) provide a small amount of consistent CPU resources and allow you to increase CPU capacity in short bursts when additional cycles are available.  They are well suited for lower throughput applications and web sites that require additional compute cycles periodically.  You can learn more about how you can use Micro instances and appropriate applications in the <a href="http://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/concepts_micro_instances.html">Amazon EC2 documentation</a></p>
-
-
-  <p style="padding-left:2em;"><strong>Micro Instance</strong></p>
-
-
-  <p style="padding-left:4em;">613 MB memory<br>
-  Up to 2 EC2 Compute Units (for short periodic bursts)<br>
-  EBS storage only<br>
-  32-bit or 64-bit platform<br>
-  I/O Performance: Low<br>
-  API name: t1.micro<br></p>
-
-      <a name="himem-instances"></a>
-  <h3>High-Memory Instances<br><br></h3>
-
-  <p style="padding-left:2em;">Instances of this family offer large memory sizes for high throughput applications, including database and memory caching applications.</p>
-
-
-  <p style="padding-left:2em;"><strong>High-Memory Extra Large Instance</strong></p>
-
-
-  <p style="padding-left:4em;">17.1 GB of memory<br>
-  6.5 EC2 Compute Units (2 virtual cores with 3.25 EC2 Compute Units each)<br>
-  420 GB of instance storage<br>
-  64-bit platform<br>
-  I/O Performance: Moderate<br>
-  API name: m2.xlarge<br></p>
-
-
-  <p style="padding-left:2em;"><strong>High-Memory Double Extra Large Instance</strong></p>
-
-
-  <p style="padding-left:4em;">34.2 GB of memory<br>
-  13 EC2 Compute Units (4 virtual cores with 3.25 EC2 Compute Units each)<br>
-  850 GB of instance storage<br>
-  64-bit platform<br>
-  I/O Performance: High<br>
-  API name: m2.2xlarge<br></p>
-
-
-  <p style="padding-left:2em;"><strong>High-Memory Quadruple Extra Large Instance</strong></p>
-
-
-  <p style="padding-left:4em;">68.4 GB of memory<br>
-  26 EC2 Compute Units (8 virtual cores with 3.25 EC2 Compute Units each)<br>
-  1690 GB of instance storage<br>
-  64-bit platform<br>
-  I/O Performance: High<br>
-  API name: m2.4xlarge<br></p>
-
-  <a name="std-instances"></a>
-  <h3>High-CPU Instances<br><br></h3>
-
-
-  <p style="padding-left:2em;">Instances of this family have proportionally more CPU resources than memory (RAM) and are well suited for compute-intensive applications.</p>
-
-
-  <p style="padding-left:2em;"><strong>High-CPU Medium Instance</strong></p>
-
-
-  <p style="padding-left:4em;">1.7 GB of memory<br>
-  5 EC2 Compute Units (2 virtual cores with 2.5 EC2 Compute Units each)<br>
-  350 GB of instance storage<br>
-  32-bit or 64-bit platform<br>
-  I/O Performance: Moderate<br>
-  API name: c1.medium<br></p>
-
-
-  <p style="padding-left:2em;"><strong>High-CPU Extra Large Instance</strong></p>
-
-
-  <p style="padding-left:4em;">7 GB of memory<br>
-  20 EC2 Compute Units (8 virtual cores with 2.5 EC2 Compute Units each)<br>
-  1690 GB of instance storage<br>
-  64-bit platform<br>
-  I/O Performance: High<br>
-  API name: c1.xlarge<br></p>
-
-    <a name="clustercompute-instances"></a>
-  <h3>Cluster Compute Instances<br><br></h3>
-
-
-  <p style="padding-left:2em;">Instances of this family provide proportionally high CPU resources with increased network performance and are well suited for High Performance Compute (HPC) applications and other demanding network-bound applications. You can learn more about Cluster instance concepts by reading the <a href="http://docs.amazonwebservices.com/AWSEC2/latest/UserGuide/using_cluster_computing.html">Amazon EC2 documentation</a>. For more information about specific use cases and cluster management options for HPC, please visit the <a href="http://aws.amazon.com/ec2/hpc-applications/">HPC solutions page</a>.</p>
-
-
-  <p style="padding-left:2em;"><strong>Cluster Compute Quadruple Extra Large Instance</strong></p>
-
-
-  <p style="padding-left:4em;">23 GB of memory<br>
-  33.5 EC2 Compute Units (2 x Intel Xeon X5570, quad-core &#8220;Nehalem&#8221; architecture)<br>
-  1690 GB of instance storage<br>
-  64-bit platform<br>
-  I/O Performance: Very High (10 Gigabit Ethernet)<br>
-  API name: cc1.4xlarge<br></p>
-
-  <p style="padding-left:2em;"><strong>Cluster Compute Eight Extra Large Instance</strong></p>
-
-
-  <p style="padding-left:4em;">60.5 GB of memory<br>
-  88 EC2 Compute Units (2 x Intel Xeon E5-2670, eight-core "Sandy Bridge" architecture)<br>
-  3370 GB of instance storage<br>
-  64-bit platform<br>
-  I/O Performance: Very High (10 Gigabit Ethernet)<br>
-  API name: cc2.8xlarge<br></p>
-
-  <a name="clustergpu-instances"></a>
-  <h3>Cluster GPU Instances<br><br></h3>
-
-
-  <p style="padding-left:2em;">Instances of this family provide general-purpose graphics processing units (GPUs) with proportionally high CPU and increased network performance for applications benefitting from highly parallelized processing, including HPC, rendering and media processing applications. While Cluster Compute Instances provide the ability to create clusters of instances connected by a low latency, high throughput network, Cluster GPU Instances provide an additional option for applications that can benefit from the efficiency gains of the parallel computing power of GPUs over what can be achieved with traditional processors. <a href="http://aws.amazon.com/ec2/hpc-applications/">Learn more</a> about use of this instance type for HPC applications.</p>
-
-
-  <p style="padding-left:2em;"><strong>Cluster GPU Quadruple Extra Large Instance</strong></p>
-
-
-  <p style="padding-left:4em;">22 GB of memory<br>
-  33.5 EC2 Compute Units (2 x Intel Xeon X5570, quad-core &#8220;Nehalem&#8221; architecture)<br>
-  2 x NVIDIA Tesla “Fermi” M2050 GPUs<br>
-  1690 GB of instance storage<br>
-  64-bit platform<br>
-  I/O Performance: Very High (10 Gigabit Ethernet)<br>
-  API name: cg1.4xlarge<br></p>
-
-
-  <h1>Selecting Instance Types</h1>
-
-
-  <p>Amazon EC2 instances are grouped into six families: Standard, Micro, High-Memory, High-CPU, Cluster Compute, and Cluster GPU.</p>
-
-
-  <p>Standard Instances have memory to CPU ratios suitable for most general purpose applications; High-Memory instances offer larger memory sizes for high throughput applications, including database and memory caching applications; and High-CPU instances have proportionally more CPU resources than memory (RAM) and are well suited for compute-intensive applications.</p>
-
-
-  <p>Micro instances provide a small amount of consistent CPU resources and allow you to burst CPU capacity when additional cycles are available. They are well suited for lower throughput applications and web sites that consume significant compute cycles periodically.  At steady state, Micro instances receive a fraction of the compute resources that Small instances do. Therefore, if your application has compute-intensive or steady state needs we recommend using a Small instance (or larger, depending on your needs).  However, Micro instances can periodically burst up to 2 ECUs (for short periods of time). This is double the number of ECUs available from a Standard Small instance. Therefore, if you have a relatively low throughput application or web site with an occasional need to consume significant compute cycles, we recommend using Micro instances.</p>
-
-
-  <p>Cluster Compute instances provide a very large amount of CPU coupled with increased network performance making them well suited for High Performance Compute (HPC) applications and other demanding network-bound applications.</p>
-
-
-  <p>Cluster GPU instances provide general-purpose graphics processing units (GPUs) with proportionally high CPU and increased network performance making them well suited for applications benefitting from highly parallelized processing, including HPC, rendering and media processing applications.</p>
-
-
-  <p>When choosing instance types, you should consider the characteristics of your application with regards to resource utilization and select the optimal instance family and size. One of the advantages of EC2 is that you pay by the instance hour, which makes it convenient and inexpensive to test the performance of your application on different instance families and types. One good way to determine the most appropriate instance family and instance type is to launch test instances and benchmark your application.</p>
-
-
-  <h1>Measuring Compute Resources</h1>
-
-
-  <p>Transitioning to a utility computing model fundamentally changes how developers have been trained to think about CPU resources.  Instead of purchasing or leasing a particular processor to use for several months or years, you are renting capacity by the hour.  Because Amazon EC2 is built on commodity hardware, over time there may be several different types of physical hardware underlying EC2 instances.  Our goal is to provide a consistent amount of CPU capacity no matter what the actual underlying hardware.</p>
-
-
-  <p>Amazon EC2 uses a variety of measures to provide each instance with a consistent and predictable amount of CPU capacity.  In order to make it easy for developers to compare CPU capacity between different instance types, we have defined an Amazon EC2 Compute Unit.  The amount of CPU that is allocated to a particular instance is expressed in terms of these EC2 Compute Units. We use several benchmarks and tests to manage the consistency and predictability of the performance of an EC2 Compute Unit. One EC2 Compute Unit provides the equivalent CPU capacity of a 1.0-1.2 GHz 2007 Opteron or 2007 Xeon processor. This is also the equivalent to an early-2006 1.7 GHz Xeon processor referenced in our original documentation. Over time, we may add or substitute measures that go into the definition of an EC2 Compute Unit, if we find metrics that will give you a clearer picture of compute capacity.</p>
-
-
-  <p>To find out which instance will work best for your application, the best thing to do is to launch an instance and benchmark your own application.  One of the advantages of EC2 is that you pay by the hour which makes it convenient and inexpensive to test the performance of your application on different instance types.</p>
-
-
-  <h1>I/O Performance</h1>
-
-
-  <p>Amazon EC2 provides virtualized server instances. While some resources like CPU, memory and instance storage are dedicated to a particular instance, other resources like the network and the disk subsystem are shared among instances.  If each instance on a physical host tries to use as much of one of these shared resources as possible, each will receive an equal share of that resource. However, when a resource is under-utilized you will often be able to consume a higher share of that resource while it is available.</p>
-
-
-  <p>The different instance types will provide higher or lower minimum performance from the shared resources depending on their size.  Each of the instance types has an I/O performance indicator (<em>low</em>, <em>moderate</em>, or <em>high</em>). Instance types with high I/O performance have a larger allocation of shared resources. Allocating larger share of shared resources also reduces the variance of I/O performance. For many applications, <em>low</em> or <em>moderate</em> I/O performance is more than enough.  However, for those applications requiring greater or more consistent I/O performance, you may want to consider instances with <em>high</em> I/O performance.</p>
-
-
-  <p>Cluster Compute and Cluster GPU instances have <em>very high</em> I/O performance using 10 Gigabit Ethernet for high network throughput and reduced network latencies within clusters.</p>
-
-
-  <p>In addition, you can use Amazon EBS to get improved storage I/O performance for disk bound applications.</p>
-
-
-  <p><br>
-  <hr/>
-  <br></p>
-
-
-  <p>*The Small Instance type is equivalent to the original Amazon EC2 instance type that has been available since Amazon EC2 launched. This instance type is currently the default for all customers. To use other instance types, customers must specifically request them via the <em>RunInstances</em> API.</p>
-  </div>
-</div>
-
-
-<div class="yui-b">
-  <div id="sideNav">
-
-
-
-
-
-
-
-
-
-
-
-<div id="subNavA">
-
-
-
-
-
-
-
-
-
-
-
-
-<div id="subPageSelector" class="products">
-  <div id="subPageComboButton"></div>
-  <div class="flyout">
-    <div class="liner">
-
-<div class="col1">
-<h4>Compute</h4>
-<ul class="">
-
-
-    <li class="">
-      <a href="/ec2/" class="">
-    Amazon Elastic Compute Cloud <span class="norm">(EC2)</span>
-  </a>
-    </li>
-
-
-    <li class="">
-      <a href="/elasticmapreduce/" class="">
-    Amazon Elastic MapReduce
-  </a>
-    </li>
-
-
-    <li class="">
-      <a href="/autoscaling/" class="">
-    Auto Scaling
-  </a>
-    </li>
-
-
-    </ul>
-
-<h4>Content Delivery</h4>
-<ul class="">
-
-
-    <li class="">
-      <a href="/cloudfront/" class="">
-    Amazon CloudFront
-  </a>
-    </li>
-
-
-    </ul>
-
-<h4>Database</h4>
-<ul class="">
-
-
-    <li class="">
-      <a href="/rds/" class="">
-    Amazon Relational Database Service <span class="norm">(RDS)</span>
-  </a>
-    </li>
-
-
-    <li class="">
-      <a href="/dynamodb/" class="">
-    Amazon DynamoDB</span>
-  </a>
-    </li>
-
-
-    <li class="">
-      <a href="/simpledb/" class="">
-    Amazon SimpleDB
-  </a>
-    </li>
-
-
-    <li class="">
-      <a href="/elasticache/" class="">
-    Amazon ElastiCache </span>
-  </a>
-    </li>
-
-
-    </ul>
-
-<h4>Deployment & Management</h4>
-<ul class="">
-
-
-    <li class="">
-      <a href="/elasticbeanstalk/" class="">
-    AWS Elastic Beanstalk
-  </a>
-    </li>
-
-
-    <li class="">
-      <a href="/cloudformation/" class="">
-    AWS CloudFormation
-  </a>
-    </li>
-
-
-    </ul>
-
-<h4>E-Commerce</h4>
-<ul class="">
-
-
-    <li class="">
-      <a href="/fws/" class="">
-    Amazon Fulfillment Web Service (FWS)
-  </a>
-    </li>
-
-
-    </ul>
-
-<h4>Industry-specific Clouds</h4>
-<ul class="">
-
-
-    <li class="">
-      <a href="/govcloud-us/" class="">
-    AWS GovCloud (US)
-  </a>
-    </li>
-
-
-    </ul>
-
-<h4>Messaging</h4>
-<ul class="">
-
-
-    <li class="">
-      <a href="/sqs/" class="">
-    Amazon Simple Queue Service <span class="norm">(SQS)</span>
-  </a>
-    </li>
-
-
-    <li class="">
-      <a href="/sns/" class="">
-    Amazon Simple   Notification Service <span class="norm">(SNS)</span>
-  </a>
-    </li>
-
-
-    <li class="">
-      <a href="/ses/" class="">
-    Amazon Simple Email Service <span class="norm">(SES)</span>
-  </a>
-    </li>
-
-
-    </ul>
-
-<h4>Monitoring</h4>
-<ul class="">
-
-
-    <li class="">
-      <a href="/cloudwatch/" class="">
-    Amazon CloudWatch
-  </a>
-    </li>
-
-
-    </ul>
-  </div>
-
-  <div class="col2">
-<h4>Networking</h4>
-<ul class="">
-
-
-    <li class="">
-      <a href="/route53/" class="">
-    Amazon Route 53
-  </a>
-    </li>
-
-
-    <li class="">
-      <a href="/vpc/" class="">
-    Amazon Virtual Private Cloud <span class="norm">(VPC)</span>
-  </a>
-    </li>
-
-
-    <li class="">
-      <a href="/elasticloadbalancing/" class="">
-    Elastic Load Balancing
-  </a>
-    </li>
-
-
-    <li class="">
-      <a href="/directconnect/" class="">
-    AWS Direct Connect
-  </a>
-    </li>
-
-
-    </ul>
-
-<h4>Payments &amp; Billing</h4>
-<ul class="">
-
-
-    <li class="">
-      <a href="/fps/" class="">
-    Amazon Flexible Payments Service <span class="norm">(FPS)</span>
-  </a>
-    </li>
-
-
-    <li class="">
-      <a href="/devpay/" class="">
-    Amazon DevPay
-  </a>
-    </li>
-
-
-    </ul>
-
-<h4>Storage</h4>
-<ul class="">
-
-
-    <li class="">
-      <a href="/s3/" class="">
-    Amazon Simple Storage Service <span class="norm">(S3)</span>
-  </a>
-    </li>
-
-
-    <li class="">
-      <a href="/ebs/" class="">
-    Amazon Elastic Block Store <span class="norm">(EBS)</span>
-  </a>
-    </li>
-
-
-    <li class="">
-      <a href="/importexport/" class="">
-    AWS Import/Export
-  </a>
-    </li>
-
-
-    </ul>
-
-<h4>Support</h4>
-<ul class="">
-
-
-    <li class="">
-      <a href="/premiumsupport/" class="">
-    AWS Premium Support
-  </a>
-    </li>
-
-
-    </ul>
-
-<h4>Web Traffic</h4>
-<ul class="">
-
-
-    <li class="">
-      <a href="/awis/" class="">Alexa Web Information Service</a>
-    </li>
-
-
-    <li class="">
-      <a href="/alexatopsites/" class="">Alexa Top Sites</a>
-    </li>
-
-
-    </ul>
-
-<h4>Workforce</h4>
-<ul class="">
-
-
-    <li class="">
-      <a href="/mturk/" class="">
-    Amazon Mechanical Turk
-  </a>
-    </li>
-
-
-    </ul>
-  </div>
-
-
-    </div>
-  </div>
-  <a href="/products/" class="noScript">Products &amp; Services</a>
-</div>
-
-
-
-
-
-  <div class="decoratedBox ">
-    <div class="head">
-      <h4>Amazon EC2 Details</h4>
-    </div>
-    <div class="body">
-      <div class="liner">
-
-  <ul class="">
-
-
-    <li class="">
-      <a href="/ec2/" class="">EC2 Overview</a>
-    </li>
-
-
-    <li class="">
-      <a href="/ec2/faqs/" class="">EC2 FAQs</a>
-    </li>
-
-
-    <li class="">
-      <a href="/ec2/pricing/" class="">EC2 Pricing</a>
-    </li>
-
-
-    <li class="">
-      <a href="/ec2-sla/" class="">Amazon EC2 SLA</a>
-    </li>
-
-
-    <li class="">
-      <a href="/ec2/instance-types/" class="selected">EC2 Instance Types</a>
-    </li>
-
-
-    <li class="">
-      <a href="/ec2/purchasing-options/" class="">EC2 Instance Purchasing Options</a>
-    </li>
-
-
-    <li class="">
-      <a href="/ec2/reserved-instances/" class="">Reserved Instances</a>
-    </li>
-
-
-    <li class="">
-      <a href="/ec2/spot-instances/" class="">Spot Instances</a>
-    </li>
-
-
-    <li class="last">
-      <a href="/windows/" class="">Windows Instances</a>
-    </li>
-
-
-    </ul>
-
-      </div>
-    </div>
-  </div>
-
-
-
-  <div class="decoratedBox last">
-    <div class="head">
-      <h4>Amazon EC2 Features</h4>
-    </div>
-    <div class="body">
-      <div class="liner">
-
-  <ul class="">
-
-
-    <li class="">
-      <a href="/ebs/" class="">Elastic Block Store</a>
-    </li>
-
-
-    <li class="">
-      <a href="/cloudwatch/" class="">Amazon CloudWatch</a>
-    </li>
-
-
-    <li class="">
-      <a href="/autoscaling/" class="">Auto Scaling</a>
-    </li>
-
-
-    <li class="">
-      <a href="/elasticloadbalancing/" class="">Elastic Load Balancing</a>
-    </li>
-
-
-    <li class="">
-      <a href="/ec2/hpc-applications/" class="">High Performance Computing</a>
-    </li>
-
-
-    <li class="last">
-      <a href="/ec2/vmimport/" class="">VM Import</a>
-    </li>
-
-
-    </ul>
-
-      </div>
-    </div>
-  </div>
-
-  </div>
-
-
-  <div id="subNavB">
-
-  <div class="decoratedBox ">
-    <div class="head">
-      <h4>Related Resources</h4>
-    </div>
-    <div class="body">
-      <div class="liner">
-
-  <ul class="">
-
-
-    <li class="">
-      <a href="/console/" class="">AWS Management Console</a>
-    </li>
-
-
-    <li class="">
-      <a href="/documentation/ec2/" class="">Documentation</a>
-    </li>
-
-
-    <li class="">
-      <a href="http://developer.amazonwebservices.com/connect/kbcategory.jspa?categoryID=86" class="">Release Notes</a>
-    </li>
-
-
-    <li class="">
-      <a href="http://developer.amazonwebservices.com/connect/kbcategory.jspa?categoryID=85" class="">Sample Code & Libraries</a>
-    </li>
-
-
-    <li class="">
-      <a href="http://developer.amazonwebservices.com/connect/kbcategory.jspa?categoryID=88" class="">Developer Tools</a>
-    </li>
-
-
-    <li class="">
-      <a href="http://developer.amazonwebservices.com/connect/kbcategory.jspa?categoryID=100" class="">Articles & Tutorials</a>
-    </li>
-
-
-    <li class="">
-      <a href="http://developer.amazonwebservices.com/connect/kbcategory.jspa?categoryID=171" class="">Amazon Machine Images (AMIs)</a>
-    </li>
-
-
-    <li class="">
-      <a href="/publicdatasets/" class="">Public Data Sets on AWS</a>
-    </li>
-
-
-    <li class="last">
-      <a href="http://developer.amazonwebservices.com/connect/forum.jspa?forumID=30" class="">Community Forum</a>
-    </li>
-
-
-    </ul>
-
-      </div>
-    </div>
-  </div>
-
-
-  <br><br><br>
-
-
-  <div class="decoratedBox last">
-    <div class="head">
-      <h4>Want to Save on Your Amazon EC2 Bill?</h4>
-    </div>
-    <div class="body">
-      <div class="liner">
-
-  <div class="liner">
-    <img src="//d36cz9buwru1tt.cloudfront.net/logo_harvard_sm2.gif"
-         width="150px"
-         class="logo"
-         title="Harvard" alt="Harvard"/>
-    <p>
-      See how customers like Harvard Medical School significantly reduced their Amazon EC2 bill by using Spot Instances.
-    </p>
-    <div class="learnMore">
-      <span class="carat">&gt;</span>
-      <a href="/ec2/spot-instances">Learn More</a>
-    </div>
-  </div>
-
-      </div>
-    </div>
-  </div>
-
-  <br><br><br>
-
-  <div class="decoratedBox ">
-    <div class="head">
-      <h4>EC2 Running Microsoft</h4>
-    </div>
-    <div class="body">
-      <div class="liner">
-
-  <div class="liner">
-    <img src="//d36cz9buwru1tt.cloudfront.net/globalNav/img/logo-microsoft.png"
-         width="137"
-         height="27"
-         class="logo"
-         alt="Microsoft"/>
-    <p>
-      Amazon EC2 running Microsoft Windows Server&reg; 2003/2008 is a fast and
-      dependable environment for deploying applications using the Microsoft Web Platform.
-    </p>
-    <div class="learnMore">
-      <span class="carat">&gt;</span>
-      <a href="/windows/">Learn More</a>
-    </div>
-  </div>
-
-      </div>
-    </div>
-  </div>
-
-
-<br><br><br>
-
-  <div class="decoratedBox last">
-    <div class="head">
-      <h4>EC2 Running IBM</h4>
-    </div>
-    <div class="body">
-      <div class="liner">
-
-  <div class="liner">
-    <img src="//d36cz9buwru1tt.cloudfront.net/globalNav/img/logo-ibm.png"
-         width="140"
-         height="53"
-         class="logo"
-         alt="IBM"/>
-    <p>
-      You can run many of the proven IBM platform technologies with which you're already familiar.
-    </p>
-    <div class="learnMore">
-      <span class="carat">&gt;</span>
-      <a href="/ibm/">Learn More</a>
-    </div>
-  </div>
-
-      </div>
-    </div>
-  </div>
-
-
-<br><br><br>
-
-  <div class="decoratedBox last">
-    <div class="head">
-      <h4>Amazon EC2 is Hiring!</h4>
-    </div>
-    <div class="body">
-      <div class="liner">
-
-  <div class="liner">
-    <img src="//d36cz9buwru1tt.cloudfront.net/logo_aws.gif"
-         width="140"
-         height="53"
-         class="logo"
-         alt="AWS"/>
-  Amazon EC2 is hiring to rapidly expand our service.
-    </p>
-    <div class="learnMore">
-      <span class="carat">&gt;</span>
-      <a href="/ec2-jobs/">Learn More</a>
-    </div>
-  </div>
-
-      </div>
-    </div>
-  </div>
-
-  </div>
-
-  <br>
-  <br>
-
-
-
-  </div>
-</div>
-
-  </div>
-  <div id="ft">
-
-
-
-
-
-
-
-
-
-
-<div style="border-top: 1px solid #ccc; margin-bottom: 12px; margin-top: 10px; padding-top: 2px;">
-<ul class="h_bar">
-  <li class="first">
-    <a href="http://aws.typepad.com/" target="_blank">AWS Blog <img src="//d36cz9buwru1tt.cloudfront.net/icon_offsite.gif" width="15" height="13" border="0" alt="This link will launch a new browser window or tab."></a>
-  </li>
-  <li><a href="http://phx.corporate-ir.net/phoenix.zhtml?c=176060&p=irol-InfoReq">Press Inquiries</a></li>
-  <li><a href="/careers/">Careers at AWS</a></li>
-  <li><a href="/contact-us/">Contact Us</a></li>
-  <li><a href="/privacy/">Privacy Policy</a></li>
-  <li><a href="/terms/">Terms of Use</a></li>
-</ul>
-<div class="grey666">&#169;2011, Amazon Web Services LLC or its affiliates. All rights reserved.</div>
-<img src="//d36cz9buwru1tt.cloudfront.net/awsmedia/logo_an_amazon_company.gif" width="160" height="21" vspace="8">
-  </div>
-
-  </div>
-</div>
-
-
-
-  </body>
-
-  </html>
+</html>
 
 
 


### PR DESCRIPTION
The local copy now once again matches the live public html from Amazon, which our parser knows how to read.
