### PR TITLE
fixed a bug that kept non vpc security groups from being preselected

### DIFF
--- a/grails-app/views/common/_securityGroupSelection.gsp
+++ b/grails-app/views/common/_securityGroupSelection.gsp
@@ -24,7 +24,7 @@
       <div class="securityGroupsSelect vpcId${vpcIdForSecurityGroup ?: ''} ${vpcId == vpcIdForSecurityGroup ? '' : 'concealed'}">
         <g:select name="selectedSecurityGroups" multiple="multiple" size="5"
                   disabled="${vpcId == vpcIdForSecurityGroup ? '' : 'true'}"
-                  optionKey="groupId" optionValue="groupName" data-placeholder="Select security groups"
+                  optionKey="${vpcId ? 'groupId' : 'groupName'}" optionValue="groupName" data-placeholder="Select security groups"
                   from="${securityGroupsGroupedByVpcId[vpcIdForSecurityGroup]}" value="${selectedSecurityGroups}" />
       </div>
     </g:each>


### PR DESCRIPTION
correctly in the ui
and hence would clear them when creating the next ASG in a cluster or doing a rolling push
