### PR TITLE
ASGARD-972 - 2nd set of instance controls should be below instances

### DIFF
--- a/grails-app/views/group/_instanceControls.gsp
+++ b/grails-app/views/group/_instanceControls.gsp
@@ -15,7 +15,7 @@
     limitations under the License.
 
 --%>
-<table>
+<table class="clear">
   <tr>
     <td colspan="100%" class="subitems">
       <div class="buttons">


### PR DESCRIPTION
On the ASG screen with a wide browser window and 18 instances, the instance controls should never be on the right hand side. They should be below the instance list.
