### PR TITLE
ASGARD-929 - Task subject emails should not have hardcoded 'nac' String

### DIFF
--- a/grails-app/services/com/netflix/asgard/Task.groovy
+++ b/grails-app/services/com/netflix/asgard/Task.groovy
@@ -52,7 +52,7 @@ class Task {
     }
 
     String getSummary() {
-        "nac${env} ${userContext?.region} task started by ${userContext?.clientHostName} ${status} in ${env}: ${name}"
+        "Asgard task ${status} in ${env} ${userContext?.region} by ${userContext?.clientHostName}: ${name}"
     }
 
     String getLogAsString() {


### PR DESCRIPTION
Also, a bit of rewording for the subject line to move short, pertinent info up front.
