### PR TITLE
ASGARD-981 - Subnet purpose selection was ignored when creating next ASG

### DIFF
--- a/grails-app/controllers/com/netflix/asgard/ClusterController.groovy
+++ b/grails-app/controllers/com/netflix/asgard/ClusterController.groovy
@@ -125,7 +125,7 @@ class ClusterController {
                             .loadBalancerNames
                     List<String> subnetIds = Relationships.subnetIdsFromVpcZoneIdentifier(lastGroup.vpcZoneIdentifier)
                     String subnetPurpose = subnets.coerceLoneOrNoneFromIds(subnetIds)?.purpose
-                    Set<String> subnetPurposes = subnets.getPurposesForZones(availabilityZones*.zoneName,
+                    List<String> subnetPurposes = subnets.getPurposesForZones(availabilityZones*.zoneName,
                             SubnetTarget.EC2).sort()
                     attributes.putAll([
                             cluster: cluster,
@@ -184,8 +184,7 @@ class ClusterController {
             String lcName = lastGroup.launchConfigurationName
             LaunchConfiguration lastLaunchConfig = awsAutoScalingService.getLaunchConfiguration(userContext, lcName)
             String appName = Relationships.appNameFromGroupName(name)
-            List<String> lastSecurityGroups = lastLaunchConfig.securityGroups
-            List<String> securityGroups = Requests.ensureList(params.selectedSecurityGroups ?: lastSecurityGroups)
+            List<String> securityGroups = Requests.ensureList(params.selectedSecurityGroups)
             List<String> selectedZones = Requests.ensureList(params.selectedZones)
             List<String> loadBalancerNames = Requests.ensureList(params.selectedLoadBalancers)
             String azRebalance = params.azRebalance
@@ -230,7 +229,8 @@ class ClusterController {
 
             Integer lastGracePeriod = lastGroup.healthCheckGracePeriod
             Subnets subnets = awsEc2Service.getSubnets(userContext)
-            String vpcZoneIdentifier = subnets.constructNewVpcZoneIdentifierForZones(lastGroup.vpcZoneIdentifier,
+            String subnetPurpose = params.subnetPurpose
+            String vpcZoneIdentifier = subnets.constructNewVpcZoneIdentifierForPurposeAndZones(subnetPurpose,
                     selectedZones)
             GroupCreateOptions options = new GroupCreateOptions(
                     common: new CommonPushOptions(

--- a/src/groovy/com/netflix/asgard/model/Subnets.groovy
+++ b/src/groovy/com/netflix/asgard/model/Subnets.groovy
@@ -175,12 +175,23 @@ import com.google.common.base.Supplier
         }
         List<String> oldSubnetIds = Relationships.subnetIdsFromVpcZoneIdentifier(vpcZoneIdentifier)
         String purpose = coerceLoneOrNoneFromIds(oldSubnetIds)?.purpose
+        constructNewVpcZoneIdentifierForPurposeAndZones(purpose, zones)
+    }
+
+    /**
+     * Construct a new VPC Zone Identifier based on a subnet purpose and a list of zones.
+     *
+     * @param  purpose is used to derive a subnet purpose from
+     * @param  zones which the new VPC Zone Identifier will contain
+     * @return a new VPC Zone Identifier or null if no purpose was specified
+     */
+    String constructNewVpcZoneIdentifierForPurposeAndZones(String purpose, List<String> zones) {
         if (purpose) {
             List<String> newSubnetIds = getSubnetIdsForZones(zones, purpose, SubnetTarget.EC2) // This is only for ASGs.
             if (newSubnetIds) {
                 return Relationships.vpcZoneIdentifierFromSubnetIds(newSubnetIds)
             }
         }
-        return null
+        null
     }
 }


### PR DESCRIPTION
Also fixed the order of purposes on Cluster show and a bug when not selecting any security groups.
