### PR TITLE
Reverting autoScaling/update redirect improvement

### DIFF
--- a/grails-app/controllers/com/netflix/asgard/AutoScalingController.groovy
+++ b/grails-app/controllers/com/netflix/asgard/AutoScalingController.groovy
@@ -403,7 +403,7 @@ class AutoScalingController {
                 nextAction = edit
             }
         }
-        redirect(action: nextAction, params: [id: name])
+        redirect(action: nextAction, params: [name: name])
     }
 
     def delete = {


### PR DESCRIPTION
Because it would cause a conflict with the Grails 2 merge. This same change will happen soon enough when Grails 2 changes get merged into master.
