### PR TITLE
patch onelogin toolkit for the JDK on our deployment machines

### DIFF
--- a/src/java/com/onelogin/saml/Response.java
+++ b/src/java/com/onelogin/saml/Response.java
@@ -56,7 +56,8 @@ public class Response {
 		
 		X509Certificate cert = certificate.getX509Cert();		
 		DOMValidateContext ctx = new DOMValidateContext(cert.getPublicKey() , nodes.item(0));				
-		XMLSignatureFactory sigF = XMLSignatureFactory.getInstance("DOM");
+		XMLSignatureFactory sigF = XMLSignatureFactory.getInstance("DOM",
+		        new org.jcp.xml.dsig.internal.dom.XMLDSigRI());
 		XMLSignature xmlSignature = sigF.unmarshalXMLSignature(ctx);
 		
 		return xmlSignature.validate(ctx);


### PR DESCRIPTION
Was throwing `java.security.NoSuchAlgorithmException: DOM XMLSignatureFactory not available`. Found fix in this message board thread http://www.coderanch.com/t/446920/Security/Mechanism-type-DOM-not-available
