### PR TITLE
fixing renderNotFound method for Grails 2.1 JSON changes

### DIFF
--- a/src/groovy/com/netflix/asgard/Requests.groovy
+++ b/src/groovy/com/netflix/asgard/Requests.groovy
@@ -145,7 +145,7 @@ class Requests {
                 controller.render(view: '/error/missing')
             }
             xml { controller.render(contentType: 'application/xml') { error(message) } }
-            json { controller.render(contentType: 'application/json') { error(message) } }
+            json { controller.render(contentType: 'application/json') { [error: message] } }
         }
     }
 }


### PR DESCRIPTION
It looks like Grails now uses Groovy's JSON support under the covers, which doesn't support the XMLBuilder syntax.
