### PR TITLE
ASGARD-995 - Make the health check pass even if caches are empty

### DIFF
--- a/grails-app/controllers/com/netflix/asgard/HealthcheckController.groovy
+++ b/grails-app/controllers/com/netflix/asgard/HealthcheckController.groovy
@@ -20,6 +20,10 @@ class HealthcheckController {
     def healthcheckService
 
     def index = {
+        render 'Healthy'
+    }
+
+    def caches = {
         if (healthcheckService.isHealthy) {
             render 'Healthy'
         } else {


### PR DESCRIPTION
Asgard is not yet architected to allow automatic failover, so having a failing health check doesn't serve a useful purpose at this point. It just stops traffic from reaching the sole Asgard, obscuring the current errors. Create /healthcheck/caches as a second health check URL for more advanced cases than load balancer checks.
