### PR TITLE
Standalone plugin

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -144,6 +144,7 @@ grails.project.dependency.resolution = {
         compile ":compress:0.4"
         compile ":context-param:1.0"
         compile ':shiro:1.1.4'
+        compile ":standalone:1.1.1"
 
         test ':spock:0.6'
 


### PR DESCRIPTION
Add ability to run Asgard as an executable jar with embedded Tomcat - similar to Jenkins. Reduces the setup steps required by our open source users.
