### PR TITLE
add monkey patching to LaunchTemplateServiceTests

### DIFF
--- a/test/unit/com/netflix/asgard/LaunchTemplateServiceTests.groovy
+++ b/test/unit/com/netflix/asgard/LaunchTemplateServiceTests.groovy
@@ -19,6 +19,10 @@ import com.netflix.asgard.mock.Mocks
 
 class LaunchTemplateServiceTests extends GroovyTestCase {
 
+    void setUp() {
+        Mocks.createDynamicMethods()
+    }
+
     void testIncludeDefaultSecurityGroups() {
         LaunchTemplateService launchTemplateService = Mocks.launchTemplateService()
         List<String> original = ["account_batch", "abcache"]


### PR DESCRIPTION
Looks like we are seeing test failures on build slaves due to unit tests executing in a different order. It's possible an object on Mocks can get initialized without monkey patching. This will then cause all downstream tests that use that object to fail, because the static object shared by all tests is misconfigured.

This may be a whack-a-mole exercise in the short term as issues like this come up. Clay and I discussed the problem, and I'm going to see if there's a quick way to reduce the amount of shared state between tests.
