### PR TITLE
ASGARD-1017 - Upgrade to AWS SDK 1.3.23 for SSL security fix

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -80,7 +80,7 @@ grails.project.dependency.resolution = {
 
         compile(
                 // Amazon Web Services programmatic interface
-                'com.amazonaws:aws-java-sdk:1.3.21',
+                'com.amazonaws:aws-java-sdk:1.3.23',
         ) {
             // AWS defines their dependencies as open-ended, which causes problems when resolving.
             // See http://stackoverflow.com/a/7990573/869


### PR DESCRIPTION
http://aws.amazon.com/security/security-bulletins/reported-ssl-certificate-validation-errors-in-api-tools-and-sdks/
