### PR TITLE
ASGARD-1020 Stop task should redirect to "show"

### DIFF
--- a/grails-app/conf/RegionFilters.groovy
+++ b/grails-app/conf/RegionFilters.groovy
@@ -43,7 +43,7 @@ class RegionFilters {
                         actionName && /* Avoid redirecting twice when both action and region are missing */
                         grailsApplication.controllerNamesToContextParams[(controllerName)].contains('region')) {
                     params.region = region.code
-                    redirect(controller: controllerName, params: params)
+                    redirect(controller: controllerName, action: actionName, params: params)
 
                     // Don't execute the controller method for this request
                     return false


### PR DESCRIPTION
Canceling a task running on a cluster object used to redirect correctly
to the show screen of a cluster. Recently it has been redirecting to a
nonsensical list URL, filtered on the cluster name (not the app name).
The resulting list is usually empty, and the list screen is the wrong
place to redirect anyway.

This behavior probably broke during the Grails 2 upgrade but no one
noticed or reported it.
