### PR TITLE
ASGARD-1022 - Fix "zone mismatch" detection

### DIFF
--- a/grails-app/controllers/com/netflix/asgard/AutoScalingController.groovy
+++ b/grails-app/controllers/com/netflix/asgard/AutoScalingController.groovy
@@ -125,7 +125,7 @@ class AutoScalingController {
 
             Collection<LoadBalancerDescription> mismatchedLoadBalancers = group.loadBalancerNames.findResults {
                 LoadBalancerDescription elb = awsLoadBalancerService.getLoadBalancer(userContext, it, From.CACHE)
-                elb.availabilityZones != groupData.availabilityZones ? elb : null
+                elb.availabilityZones.sort() != groupData.availabilityZones ? elb : null
             }
             Map<String, List<String>> mismatchedElbNamesToZoneLists = mismatchedLoadBalancers.collectEntries {
                 [it.loadBalancerName, it.availabilityZones.sort()]

--- a/grails-app/views/loadBalancer/show.gsp
+++ b/grails-app/views/loadBalancer/show.gsp
@@ -175,8 +175,8 @@
               <g:each in="${groups}" var="g">
                 <tr class="prop">
                   <td><g:linkObject type="autoScaling" name="${g.autoScalingGroupName}"/></td>
-                  <g:if test="${g.availabilityZones != loadBalancer.availabilityZones}">
-                    <td><g:render template="/common/zoneMismatch" model="[asgZones: g.availabilityZones, elbZones: loadBalancer.availabilityZones]"/></td>
+                  <g:if test="${g.availabilityZones.sort() != loadBalancer.availabilityZones.sort()}">
+                    <td><g:render template="/common/zoneMismatch" model="[asgZones: g.availabilityZoness.sort(), elbZones: loadBalancer.availabilityZones.sort()]"/></td>
                   </g:if>
                 </tr>
               </g:each>


### PR DESCRIPTION
It turns out that it is possible for the zones to be in the wrong
order on the ASG object, so sort the zones as needed for comparison.
The volume of items is always small, so sorting is cheap.
