### PR TITLE
ASGARD-1035 - Remove appname_1 convention

### DIFF
--- a/grails-app/services/com/netflix/asgard/AwsAutoScalingService.groovy
+++ b/grails-app/services/com/netflix/asgard/AwsAutoScalingService.groovy
@@ -263,8 +263,9 @@ class AwsAutoScalingService implements CacheInitializer, InitializingBean {
     }
 
     List<AutoScalingGroup> getAutoScalingGroupsForApp(UserContext userContext, String appName) {
-        def pat = ~/^${appName.toLowerCase()}(?:_\d+)?(?:-.+)?$/
-        getAutoScalingGroups(userContext).findAll { it.autoScalingGroupName ==~ pat }
+        getAutoScalingGroups(userContext).findAll {
+            appName.toLowerCase() == Relationships.appNameFromGroupName(it.autoScalingGroupName)
+        }
     }
 
     AutoScalingGroup getAutoScalingGroup(UserContext userContext, String name, From from = From.AWS) {


### PR DESCRIPTION
Remove the special parsing rule for trailing underscore-number tokens 
on application names.

We no longer need the surprising, arcane convention that clusters 
should be included in searches for an application name like fido, 
even if the actual app name of the cluster is fido_0 or fido_1.
