### PR TITLE
ASGARD-1046 Suppress emails for dupe SGs

### DIFF
--- a/grails-app/services/com/netflix/asgard/TaskService.groovy
+++ b/grails-app/services/com/netflix/asgard/TaskService.groovy
@@ -30,9 +30,9 @@ import org.codehaus.groovy.runtime.StackTraceUtils
 class TaskService {
 
     static transactional = false
-    private static final Collection<String> NON_ALERTABLE_ERROR_CODES = ['ValidationError', 'InvalidParameterValue',
-            'InvalidGroup.InUse', 'DBInstanceAlreadyExists', 'DuplicateLoadBalancerName', 'InvalidDBInstanceState',
-            'InvalidDBSnapshotState', 'InvalidGroup.Duplicate']
+    private static final Collection<String> NON_ALERTABLE_ERROR_CODES = ['DBInstanceAlreadyExists',
+            'DuplicateLoadBalancerName', 'InvalidDBInstanceState', 'InvalidDBSnapshotState', 'InvalidGroup.Duplicate',
+            'InvalidGroup.InUse', 'InvalidParameterValue', 'ValidationError']
 
     def awsSimpleDbService
     def emailerService


### PR DESCRIPTION
ASGARD-1046 - Suppress system alert emails for InvalidGroup.Duplicate security group creations

Also, alphabetize the growing list of non-alertable error codes.
