### PR TITLE
fix inconsistent license header

### DIFF
--- a/grails-app/controllers/com/netflix/asgard/SubnetController.groovy
+++ b/grails-app/controllers/com/netflix/asgard/SubnetController.groovy
@@ -5,7 +5,7 @@
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
  *
- *  http://aws.amazon.com/apache2.0
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either

--- a/src/groovy/com/netflix/asgard/model/SubnetData.groovy
+++ b/src/groovy/com/netflix/asgard/model/SubnetData.groovy
@@ -5,7 +5,7 @@
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
  *
- *  http://aws.amazon.com/apache2.0
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either

--- a/src/groovy/com/netflix/asgard/model/SubnetTarget.groovy
+++ b/src/groovy/com/netflix/asgard/model/SubnetTarget.groovy
@@ -5,7 +5,7 @@
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
  *
- *  http://aws.amazon.com/apache2.0
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either

--- a/src/groovy/com/netflix/asgard/model/Subnets.groovy
+++ b/src/groovy/com/netflix/asgard/model/Subnets.groovy
@@ -5,7 +5,7 @@
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
  *
- *  http://aws.amazon.com/apache2.0
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either


### PR DESCRIPTION
Make sure the url always points to Apache's url.
