### PR TITLE
ASGARD-1031 - Logout of OneLogin properly

### DIFF
--- a/grails-app/controllers/com/netflix/asgard/AuthController.groovy
+++ b/grails-app/controllers/com/netflix/asgard/AuthController.groovy
@@ -42,7 +42,8 @@ class AuthController {
         def principal = SecurityUtils.subject?.principal
         SecurityUtils.subject?.logout()
         ConfigUtils.removePrincipal(principal)
-        String redirectUri = params.targetUri ?: '/'
+        String logoutUrl = pluginService.authenticationProvider.logoutUrl(request) ?: params.targetUri
+        String redirectUri = logoutUrl ?: '/'
         redirect(uri: redirectUri)
     }
 }

--- a/grails-app/services/com/netflix/asgard/ConfigService.groovy
+++ b/grails-app/services/com/netflix/asgard/ConfigService.groovy
@@ -437,6 +437,13 @@ class ConfigService {
     }
 
     /**
+     * @return URL to redirect user to on logout to terminate OneLogin session.
+     */
+    String getOneLoginLogoutUrl() {
+        grailsApplication.config.security?.onelogin?.logoutUrl ?: null
+    }
+
+    /**
      * @return Certificate provided by OneLogin used to validate SAML tokens.
      */
     String getOneLoginCertificate() {

--- a/src/groovy/com/netflix/asgard/auth/OneLoginAuthenticationProvider.groovy
+++ b/src/groovy/com/netflix/asgard/auth/OneLoginAuthenticationProvider.groovy
@@ -93,4 +93,9 @@ class OneLoginAuthenticationProvider implements AuthenticationProvider {
             suffix ? samlResponse.nameId.replaceAll("${suffix}\$", '') : samlResponse.nameId
         }
     }
+
+    @Override
+    public String logoutUrl(HttpServletRequest request) {
+        configService.oneLoginLogoutUrl
+    }
 }

--- a/src/groovy/com/netflix/asgard/plugin/AuthenticationProvider.groovy
+++ b/src/groovy/com/netflix/asgard/plugin/AuthenticationProvider.groovy
@@ -33,6 +33,11 @@ interface AuthenticationProvider {
     String loginUrl(HttpServletRequest request)
 
     /**
+     * @return A url to redirect to when the logout link is clicked.
+     */
+    String logoutUrl(HttpServletRequest request)
+
+    /**
      * Build the Asgard login token based on a request sent to the auth/signIn endpoint.
      *
      * @param request The http request sent to the endpoint


### PR DESCRIPTION
Redirect to the OneLogin logout page when logging out of Asgard.
