### PR TITLE
minor unit test fixes

### DIFF
--- a/src/groovy/com/netflix/asgard/mock/Mocks.groovy
+++ b/src/groovy/com/netflix/asgard/mock/Mocks.groovy
@@ -496,6 +496,7 @@ class Mocks {
             awsCloudWatchService = awsCloudWatchService()
             emailerService = emailerService()
             awsSimpleDbService = awsSimpleDbService()
+            configService = configService()
             afterPropertiesSet()
             initializeCaches()
             waitForFill(caches.allAutoScalingGroups)

--- a/test/unit/com/netflix/asgard/AwsAutoScalingServiceUnitSpec.groovy
+++ b/test/unit/com/netflix/asgard/AwsAutoScalingServiceUnitSpec.groovy
@@ -37,16 +37,13 @@ import com.netflix.asgard.model.AlarmData.Statistic
 import com.netflix.asgard.model.AutoScalingGroupData
 import com.netflix.asgard.model.AutoScalingProcessType
 import com.netflix.asgard.model.ScalingPolicyData
+import com.netflix.asgard.model.StackItem
 import spock.lang.Specification
 
 @SuppressWarnings(["GroovyAssignabilityCheck"])
 class AwsAutoScalingServiceUnitSpec extends Specification {
 
-    final awsAutoScalingService = Mocks.newAwsAutoScalingService()
-
-    def setup() {
-        Mocks.createDynamicMethods() 
-    }
+    AwsAutoScalingService awsAutoScalingService
 
     def 'should update ASG with proper AWS requests'() {
         final mockAmazonAutoScalingClient = Mock(AmazonAutoScaling)
@@ -59,6 +56,7 @@ class AwsAutoScalingServiceUnitSpec extends Specification {
         }
         mockAmazonAutoScalingClient.describePolicies(_) >> {[]}
 
+        awsAutoScalingService = Mocks.newAwsAutoScalingService()
         awsAutoScalingService.awsClient = new MultiRegionAwsClient({mockAmazonAutoScalingClient})
 
         //noinspection GroovyAccessibility
@@ -112,6 +110,7 @@ class AwsAutoScalingServiceUnitSpec extends Specification {
         mockAmazonAutoScalingClient.describeAutoScalingGroups(_) >> {
             new DescribeAutoScalingGroupsResult()
         }
+        awsAutoScalingService = Mocks.newAwsAutoScalingService()
         awsAutoScalingService.awsClient = new MultiRegionAwsClient({mockAmazonAutoScalingClient})
 
         final AutoScalingGroup groupTemplate = new AutoScalingGroup().withAutoScalingGroupName('helloworld-example').
@@ -144,6 +143,7 @@ class AwsAutoScalingServiceUnitSpec extends Specification {
     }
 
     def 'should get scaling policies'() {
+        awsAutoScalingService = new AwsAutoScalingService()
         final mockAmazonAutoScalingClient = Mock(AmazonAutoScaling)
         awsAutoScalingService.awsClient = new MultiRegionAwsClient({mockAmazonAutoScalingClient})
         final AwsCloudWatchService mockAwsCloudWatchService = Mock(AwsCloudWatchService)


### PR DESCRIPTION
Lack of a Mock's dependency was causing an error message to be displayed.
Unnecessary use of the Mocks class in unit tests greatly slows them down.
