### PR TITLE
emergency patch for instance types

### DIFF
--- a/grails-app/services/com/netflix/asgard/InstanceTypeService.groovy
+++ b/grails-app/services/com/netflix/asgard/InstanceTypeService.groovy
@@ -133,16 +133,21 @@ class InstanceTypeService implements CacheInitializer {
             RegionalInstancePrices reservedPrices = getReservedPrices(region)
             RegionalInstancePrices spotPrices = getSpotPrices(region)
 
-            List<InstanceTypeData> instanceTypes = InstanceType.values().collect { InstanceType instanceType ->
+            Set<InstanceType> awsInstanceTypes = InstanceType.values() as Set
+            List<InstanceTypeData> instanceTypes = awsInstanceTypes.findResults { InstanceType instanceType ->
                 HardwareProfile hardwareProfile = hardwareProfiles.find { it.instanceType == instanceType.toString() }
+                if (!hardwareProfile) {
+                    log.info "Unable to resolve ${instanceType}"
+                    return null
+                }
                 new InstanceTypeData(
-                        hardwareProfile: hardwareProfile,
-                        linuxOnDemandPrice: onDemandPrices.get(instanceType, InstanceProductType.LINUX_UNIX),
-                        linuxReservedPrice: reservedPrices.get(instanceType, InstanceProductType.LINUX_UNIX),
-                        linuxSpotPrice: spotPrices.get(instanceType, InstanceProductType.LINUX_UNIX),
-                        windowsOnDemandPrice: onDemandPrices.get(instanceType, InstanceProductType.WINDOWS),
-                        windowsReservedPrice: reservedPrices.get(instanceType, InstanceProductType.WINDOWS),
-                        windowsSpotPrice: spotPrices.get(instanceType, InstanceProductType.WINDOWS)
+                    hardwareProfile: hardwareProfile,
+                    linuxOnDemandPrice: onDemandPrices.get(instanceType, InstanceProductType.LINUX_UNIX),
+                    linuxReservedPrice: reservedPrices.get(instanceType, InstanceProductType.LINUX_UNIX),
+                    linuxSpotPrice: spotPrices.get(instanceType, InstanceProductType.LINUX_UNIX),
+                    windowsOnDemandPrice: onDemandPrices.get(instanceType, InstanceProductType.WINDOWS),
+                    windowsReservedPrice: reservedPrices.get(instanceType, InstanceProductType.WINDOWS),
+                    windowsSpotPrice: spotPrices.get(instanceType, InstanceProductType.WINDOWS)
                 )
             }
             // Only include types that have prices listed for this region


### PR DESCRIPTION
The cc1.4xlarge has disappeared, causing the list to show up as empty.
