### PR TITLE
Removed Chaos Monkey status on show App and ASG pages.

### DIFF
--- a/grails-app/controllers/com/netflix/asgard/ApplicationController.groovy
+++ b/grails-app/controllers/com/netflix/asgard/ApplicationController.groovy
@@ -145,9 +145,6 @@ class ApplicationController {
                     isChaosMonkeyActive: isChaosMonkeyActive,
                     chaosMonkeyEditLink: cloudReadyService.constructChaosMonkeyEditLink(userContext.region, app.name)
             ]
-            if (isChaosMonkeyActive) {
-                details.chaosMonkeyStatus = cloudReadyService.chaosMonkeyStatusForApplication(app.name)
-            }
             withFormat {
                 html { return details }
                 xml { new XML(details).render(response) }

--- a/grails-app/controllers/com/netflix/asgard/AutoScalingController.groovy
+++ b/grails-app/controllers/com/netflix/asgard/AutoScalingController.groovy
@@ -195,10 +195,6 @@ class AutoScalingController {
                     isChaosMonkeyActive: isChaosMonkeyActive,
                     chaosMonkeyEditLink: cloudReadyService.constructChaosMonkeyEditLink(userContext.region, appName)
             ]
-            if (isChaosMonkeyActive) {
-                Region region = userContext.region
-                details.chaosMonkeyStatus = cloudReadyService.chaosMonkeyStatusForCluster(region, clusterName)
-            }
             withFormat {
                 html { return details }
                 xml { new XML(details).render(response) }

--- a/grails-app/views/application/show.gsp
+++ b/grails-app/views/application/show.gsp
@@ -75,7 +75,7 @@
         <g:if test="${isChaosMonkeyActive}">
           <tr class="prop">
             <td class="name">Chaos Monkey:</td>
-            <td class="value">${chaosMonkeyStatus}<a class="cloudready" href="${chaosMonkeyEditLink}">Edit in Cloudready</a></td>
+            <td class="value"><a class="cloudready" href="${chaosMonkeyEditLink}">Edit in Cloudready</a></td>
           </tr>
         </g:if>
         <tr class="prop">

--- a/grails-app/views/autoScaling/show.gsp
+++ b/grails-app/views/autoScaling/show.gsp
@@ -134,7 +134,7 @@
         <g:if test="${isChaosMonkeyActive}">
           <tr class="prop">
             <td class="name">Chaos Monkey:</td>
-            <td class="value">${chaosMonkeyStatus}<a class="cloudready" href="${chaosMonkeyEditLink}">Edit in Cloudready</a></td>
+            <td class="value"><a class="cloudready" href="${chaosMonkeyEditLink}">Edit in Cloudready</a></td>
           </tr>
         </g:if>
         <tr class="prop">


### PR DESCRIPTION
The information isn't important enough to make the call to cloudready.
