### PR TITLE
ASGARD-1067 - Better error handling for OneLogin authentication failures

### DIFF
--- a/src/groovy/com/netflix/asgard/auth/OneLoginAuthenticationProvider.groovy
+++ b/src/groovy/com/netflix/asgard/auth/OneLoginAuthenticationProvider.groovy
@@ -77,7 +77,11 @@ class OneLoginAuthenticationProvider implements AuthenticationProvider {
             AccountSettings accountSettings = new AccountSettings(certificate: configService.oneLoginCertificate)
 
             samlResponse = new Response(accountSettings)
-            samlResponse.loadXmlFromBase64(samlResponseString)
+            try {
+                samlResponse.loadXmlFromBase64(samlResponseString)
+            } catch (Exception e) {
+                throw new AuthenticationException("Unable to parse response from OneLogin: ${samlResponseString}", e)
+            }
         }
 
         boolean isValid() {


### PR DESCRIPTION
Getting a mystery NPE from OneLogin's code.
