### PR TITLE
removing the CodeNarc check for public methods in a controller

### DIFF
--- a/grails-app/conf/CodeNarcRuleSet.groovy
+++ b/grails-app/conf/CodeNarcRuleSet.groovy
@@ -172,9 +172,7 @@ ruleset {
     // rulesets/grails.xml
 //    GrailsDomainHasEquals
 //    GrailsDomainHasToString
-    GrailsPublicControllerMethod {
-        priority = 1
-    }
+//    GrailsPublicControllerMethod
     GrailsServletContextReference
     GrailsSessionReference
 //    GrailsStatelessService


### PR DESCRIPTION
This was in place to protect us from methods that were inadvertently public in preparation for a Grails 2 upgrade where they would become visible actions. The rule should be suppressed now that we are in Grails 2 and using methods for actions is preferred.
