### PR TITLE
ASGARD-1075 Disable form submit on keyboard enter key

### DIFF
--- a/grails-app/views/home/index.gsp
+++ b/grails-app/views/home/index.gsp
@@ -99,7 +99,7 @@
         </ul>
       </div>
       <div class="widget">
-        <g:form controller="instance" action="show" method="get" class="instanceJump">
+        <g:form controller="instance" action="show" method="get" class="instanceJump allowEnterKeySubmit">
         <h1><label for="txtInstanceId">Jump to an instance</label></h1>
         <ul>
           <li>

--- a/grails-app/views/layouts/main.gsp
+++ b/grails-app/views/layouts/main.gsp
@@ -78,7 +78,7 @@
         </shiro:isNotLoggedIn>
       </g:if>
       <div class="search" title="Find entities by name">
-        <form action="/search" method="GET">
+        <form action="/search" method="GET" class="allowEnterKeySubmit">
           %{--<input type="search" results="10" autosave="asgard${env}globalsearch" name="q" placeholder="Global search by names" value="${params.q}">--}%
         </form>
       </div>

--- a/web-app/js/custom.js
+++ b/web-app/js/custom.js
@@ -586,6 +586,12 @@ jQuery(document).ready(function() {
         // Don't let any ajax responses use browser cache
         jQuery.ajaxSetup({ cache: false });
 
+        // Ignore "Enter" key on forms. It's too easy to press enter again by accident after using enter to make a
+        // select2 choice. This usability flaw can cause production outages.
+        jQuery('form').not('.allowEnterKeySubmit').bind('keydown', function(e) {
+            return e.keyCode !== 13;
+        });
+
         // Decorate the menu buttons that have drop down lists. Do the work that CSS3 isn't ready to do yet.
         jQuery('.menuButton').has('ul').addClass('dropdown');
 


### PR DESCRIPTION
The default browser behavior that allows the Enter key to submit the
form is dangerous and usually unnecessary. This danger has been
uncovered by a user navigating a select2 mutli-select input rapidly
with the keyboard, trying to add many ELBs to an ASG rapidly. The
form submitted early because of the Enter key, resulting in an ASG
that unintentionally lacked security groups.

For certain whitelisted, one-field forms that don't result in backend
state changes, the Enter key can be allowed to submit the form. That
makes those forms easier to use. For example, any form that merely
does a search or a browser redirect.
