### PR TITLE
ASGARD-1080 - API Token with '+' in hash string fails to validate

### DIFF
--- a/src/groovy/com/netflix/asgard/auth/ApiToken.groovy
+++ b/src/groovy/com/netflix/asgard/auth/ApiToken.groovy
@@ -133,7 +133,7 @@ class ApiToken implements AuthenticationToken {
      * @return String representation of this token. Token can be reconstructed using {@link fromApiTokenString(String)}
      */
     String getTokenString() {
-        List<String> components = [purpose, TOKEN_DATE_FORMAT.print(expires), username, hash]
+        List<String> components = [purpose, TOKEN_DATE_FORMAT.print(expires), username, URLEncoder.encode(hash)]
         if (username != email) {
             components << email
         }

--- a/test/unit/com/netflix/asgard/auth/ApiTokenSpec.groovy
+++ b/test/unit/com/netflix/asgard/auth/ApiTokenSpec.groovy
@@ -44,11 +44,11 @@ class ApiTokenSpec extends Specification {
         tokens[0] == 'TestScript'
         ApiToken.TOKEN_DATE_FORMAT.parseDateTime(tokens[1]) == new DateTime().plusDays(30).withMillisOfDay(0)
         tokens[2] == 'testUser@netflix.com'
-        tokens[3] ==~ /[a-zA-Z0-9\+\/]{8}/
+        tokens[3] ==~ /[a-zA-Z0-9\%]{8,24}/
         tokens[4] == 'testDL@netflix.com'
 
         when:
-        ApiToken parsedToken = ApiToken.fromApiTokenString(tokenString)
+        ApiToken parsedToken = ApiToken.fromApiTokenString(URLDecoder.decode(tokenString))
 
         then:
         parsedToken.isValid('key')
@@ -66,10 +66,10 @@ class ApiTokenSpec extends Specification {
         tokens[0] == 'TestScript'
         ApiToken.TOKEN_DATE_FORMAT.parseDateTime(tokens[1]) == new DateTime().plusDays(30).withMillisOfDay(0)
         tokens[2] == 'testUser@netflix.com'
-        tokens[3] ==~ /[a-zA-Z0-9\+\/]{8}/
+        tokens[3] ==~ /[a-zA-Z0-9\%]{8,24}/
 
         when:
-        ApiToken parsedToken = ApiToken.fromApiTokenString(tokenString)
+        ApiToken parsedToken = ApiToken.fromApiTokenString(URLDecoder.decode(tokenString))
 
         then:
         parsedToken.isValid('key')
@@ -79,7 +79,7 @@ class ApiTokenSpec extends Specification {
         String semiEternalToken = 'TestScript:2833-12-20:testUser@netflix.com:xh20q18Y:testDL@netflix.com'
 
         when:
-        ApiToken parsedToken = ApiToken.fromApiTokenString(semiEternalToken)
+        ApiToken parsedToken = ApiToken.fromApiTokenString(URLDecoder.decode(semiEternalToken))
 
         then:
         parsedToken.isValid('key')


### PR DESCRIPTION
URL encode the hash before displaying to the user.
