### PR TITLE
ASGARD-1086 - Fast property nav link to sub-lists

### DIFF
--- a/grails-app/services/com/netflix/asgard/FastPropertyService.groovy
+++ b/grails-app/services/com/netflix/asgard/FastPropertyService.groovy
@@ -71,14 +71,15 @@ class FastPropertyService implements CacheInitializer {
     }
 
     /**
-     * Finds all fast properties associated with the supplied application name, based on the region in the user context.
+     * Finds all fast properties associated with the supplied application name (case insensitive), based on the region
+     * in the user context.
      *
      * @param userContext who, where, why
      * @param name the application name
      * @return list of fast properties associated with the application
      */
     List<FastProperty> getFastPropertiesByAppName(UserContext userContext, String name) {
-        getAll(userContext).findAll { it.appId == name }
+        getAll(userContext).findAll { name.compareToIgnoreCase(it.appId) }
     }
 
     private UriComponentsBuilder fastPropertyBaseUriBuilder(userContext) {

--- a/grails-app/views/fastProperty/apps.gsp
+++ b/grails-app/views/fastProperty/apps.gsp
@@ -1,0 +1,59 @@
+<%--
+
+    Copyright 2013 Netflix, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+--%>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <meta name="layout" content="main"/>
+  <title>Fast Properties</title>
+</head>
+
+<body>
+<div class="body">
+  <h1>Links to sub-lists of Fast Properties in ${region.description}</h1>
+  <g:if test="${flash.message}">
+    <div class="message">${flash.message}</div>
+  </g:if>
+  <div class="list">
+    <div class="buttons">
+      <g:link class="create" action="create">Create New Fast Property</g:link>
+    </div>
+    <table class="sortable fastProperties">
+      <thead>
+      <tr>
+        <th>Sub-List by Application</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr class="even">
+        <td><g:link class="fastProperty" controller="fastProperty" action="list">(All)</g:link></td>
+      </tr>
+      <tr class="odd">
+        <td><g:link class="fastProperty" controller="fastProperty" action="list" id="${noAppId}">(No App)</g:link></td>
+      </tr>
+      <g:each var="appName" in="${appNames}" status="i">
+        <tr class="${(i % 2) == 0 ? 'odd' : 'even'}">
+          <td><g:link class="fastProperty" controller="fastProperty" action="list" id="${appName}">${appName}</g:link></td>
+        </tr>
+      </g:each>
+      </tbody>
+    </table>
+  </div>
+  <div class="paginateButtons"></div>
+</div>
+</body>
+</html>

--- a/grails-app/views/layouts/main.gsp
+++ b/grails-app/views/layouts/main.gsp
@@ -95,7 +95,7 @@
          <li class="menuButton"><g:link class="users" controller="application" action="owner">Owners</g:link></li>
          <li class="menuButton"><g:link class="securityGroups" controller="security" action="list">Security Groups</g:link></li>
          <g:if test="${platformserviceExists}">
-           <li class="menuButton"><g:link class="fastProperties" controller="fastProperty" action="list">Fast Properties</g:link></li>
+           <li class="menuButton"><g:link class="fastProperties" controller="fastProperty" action="apps">Fast Properties</g:link></li>
          </g:if>
        </ul>
      </li>


### PR DESCRIPTION
Make a page of Fast Property links to all the sub-lists of applications,
a plus a link to the no-app properties, and a link to full list of
properties. Make the Fast Property nav link point to that new page.
Also make the app-based list filter case-insensitive.
