### PR TITLE
Edit link should not be displayed for regions without Chaos Monkey

### DIFF
--- a/grails-app/controllers/com/netflix/asgard/ApplicationController.groovy
+++ b/grails-app/controllers/com/netflix/asgard/ApplicationController.groovy
@@ -134,7 +134,7 @@ class ApplicationController {
                     groups.collect { Relationships.clusterFromGroupName(it.autoScalingGroupName) }.unique()
             request.alertingServiceConfigUrl = configService.alertingServiceConfigUrl
             SecurityGroup appSecurityGroup = awsEc2Service.getSecurityGroup(userContext, name)
-            boolean isChaosMonkeyActive = cloudReadyService.isChaosMonkeyActive()
+            boolean isChaosMonkeyActive = cloudReadyService.isChaosMonkeyActive(userContext.region)
             def details = [
                     app: app,
                     strictName: Relationships.checkStrictName(app.name),


### PR DESCRIPTION
Even though apps span regions, this link is for showing clusters of an app specific to a region and cloud ready currently breaks with an unhelpful if Chaos Monkey is not available in a region.
