### PR TITLE
ASGARD-1092 - NPE on adding new scaling policy and alarm using Java 7

### DIFF
--- a/grails-app/services/com/netflix/asgard/CachedMap.groovy
+++ b/grails-app/services/com/netflix/asgard/CachedMap.groovy
@@ -253,7 +253,7 @@ class CachedMap<T> implements Fillable {
     void putAllAndRemoveMissing(Collection<String> names, Collection<T> values) {
 
         // Things that exist
-        Map<String, T> namesToValues = values.inject([:]) { Map map, T value -> map << [(entityType.key(value)): value] } as Map
+        Map<String, T> namesToValues = values.collectEntries { [entityType.key(it), it] }
         putAll(namesToValues)
 
         // Thing that don't exist


### PR DESCRIPTION
Turns out the problem was using the `T` generic argument type in the closure args.
