### PR TITLE
emergency change to Disable Instance Additions to ELB label

### DIFF
--- a/grails-app/views/autoScaling/edit.gsp
+++ b/grails-app/views/autoScaling/edit.gsp
@@ -88,7 +88,7 @@
               <input type="radio" name="addToLoadBalancer" value="enabled" id="addToLoadBalancerEnabled" ${addToLoadBalancerSuspended ?  '' : 'checked="checked"'}>
               <label for="addToLoadBalancerEnabled" class="choice">Allow Group to Add Instances to ELB</label><br/>
               <input type="radio" name="addToLoadBalancer" value="disabled" id="addToLoadBalancerDisabled" ${addToLoadBalancerSuspended ? 'checked="checked"' : ''}>
-              <label for="addToLoadBalancerDisabled" class="choice">Disable Instance Additions to ELB</label>
+              <label for="addToLoadBalancerDisabled" class="choice">Disable Instance Additions to ELB (disables all instances in Discovery)</label>
             </td>
           </tr>
           </tbody>


### PR DESCRIPTION
Warn users their instances will go out of service in Eureka if they use the 'Disable Instance Additions to ELB' radio button on the edit ASG page.
