### PR TITLE
ASGARD-1100 - Leave default AMI id blank on create ASG page.

### DIFF
--- a/grails-app/controllers/com/netflix/asgard/GroupCreateCommand.groovy
+++ b/grails-app/controllers/com/netflix/asgard/GroupCreateCommand.groovy
@@ -29,6 +29,7 @@ import grails.validation.Validateable
     String detail
     String chaosMonkey
     String region
+    String imageId
     boolean requestedFromGui
     boolean appWithClusterOptLevel
 
@@ -96,5 +97,6 @@ import grails.validation.Validateable
             }
         })
 
+        imageId(nullable: false, blank: false)
     }
 }

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -116,3 +116,6 @@ initializeCommand.accountNumber.matches.error=Account number should be 12 digits
 generateApiTokenCommand.purpose.matches.error=Purpose can only contain letters, numbers, underscores, dots, and hyphens.
 
 chaosMonkey.optIn.missing.error=Chaos Monkey selection is required.
+
+groupCreateCommand.imageId.blank.error=AMI Image Id is required.
+groupCreateCommand.imageId.null.error=AMI Image Id is required.

--- a/grails-app/views/launchConfiguration/_launchConfigOptions.gsp
+++ b/grails-app/views/launchConfiguration/_launchConfigOptions.gsp
@@ -28,7 +28,8 @@
       <label for="imageId">AMI Image ID:</label>
     </td>
     <td>
-      <select id="imageId" name="imageId">
+      <select id="imageId" name="imageId" data-placeholder="-Image Id-">
+        <option value=""></option>
         <g:each var="im" in="${images}">
           <option value="${im.imageId}" ${params.imageId == im.imageId || im.imageId == image ? "selected" : ""}>${im.imageLocation} | ${im.imageId}</option>
         </g:each>


### PR DESCRIPTION
Make the AMI selector have a default blank value with the 'Image Id' placeholder. Add validation through the group create command object. The blank value will be hidden by select2, so no need to make it conditional.
