### PR TITLE
Test for InstanceTypeData assumes currency is always $

### DIFF
--- a/test/unit/com/netflix/asgard/model/InstanceTypeDataTests.groovy
+++ b/test/unit/com/netflix/asgard/model/InstanceTypeDataTests.groovy
@@ -15,11 +15,13 @@
  */
 package com.netflix.asgard.model
 
+import java.text.NumberFormat
+
 class InstanceTypeDataTests extends GroovyTestCase {
 
     void testGetMonthlyLinuxOnDemandPrice() {
-        assert '$72.00' == new InstanceTypeData(linuxOnDemandPrice: 0.10).monthlyLinuxOnDemandPrice
-        assert '$274.39' == new InstanceTypeData(linuxOnDemandPrice: 0.3811).monthlyLinuxOnDemandPrice
+        assert NumberFormat.getCurrencyInstance().format(72) == new InstanceTypeData(linuxOnDemandPrice: 0.10).monthlyLinuxOnDemandPrice
+        assert NumberFormat.getCurrencyInstance().format(274.39) == new InstanceTypeData(linuxOnDemandPrice: 0.3811).monthlyLinuxOnDemandPrice
     }
 
     void testGetMonthlyLinuxOnDemandPriceNull() {


### PR DESCRIPTION
This test was failing because it assumes that the local currency is always $. This means that if your locale happens to use a different currency symbol ( £ or Euro ), the test will fail consistently. 

This change makes Asgard friendlier to non-US based developers. 
