### PR TITLE
fixed DateTime assert to work on all builds

### DIFF
--- a/test/unit/com/netflix/asgard/FastPropertySpec.groovy
+++ b/test/unit/com/netflix/asgard/FastPropertySpec.groovy
@@ -17,6 +17,7 @@ package com.netflix.asgard
 
 import grails.converters.XML
 import groovy.util.slurpersupport.GPathResult
+import org.joda.time.DateTime
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -118,7 +119,7 @@ class FastPropertySpec extends Specification {
 
     def 'should calculate expiration'() {
         expect:
-        new FastProperty(ts: '2013-01-18T00:59:46.771Z', ttl: '999').expires
+        new FastProperty(ts: '2013-01-18T00:59:46.771Z', ttl: '999').expires == new DateTime('2013-01-18T01:16:25.771Z')
     }
 
     def 'should not calculate without ttl'() {


### PR DESCRIPTION
This test was brittle before because the way that I was constructing the expected DateTime was dependent on local.
The Z means that the date is UTC. And this should work everywhere.
