### PR TITLE
ASGARD-1119 - Fix AMI launch NPE

### DIFF
--- a/grails-app/controllers/com/netflix/asgard/ImageController.groovy
+++ b/grails-app/controllers/com/netflix/asgard/ImageController.groovy
@@ -147,9 +147,7 @@ class ImageController {
     def prelaunch = {
         UserContext userContext = UserContext.of(request)
         String imageId = EntityType.image.ensurePrefix(params.id)
-        Image image = awsEc2Service.getImage(userContext, imageId)
-        Collection<InstanceTypeData> instanceTypes =
-                instanceTypeService.findRelevantInstanceTypesForImage(userContext, image)
+        Collection<InstanceTypeData> instanceTypes = instanceTypeService.getInstanceTypes(userContext)
         [
                  'imageId' : imageId,
                  'instanceType' : '',

--- a/grails-app/services/com/netflix/asgard/InstanceTypeService.groovy
+++ b/grails-app/services/com/netflix/asgard/InstanceTypeService.groovy
@@ -47,7 +47,6 @@ class InstanceTypeService implements CacheInitializer {
 
     final BigDecimal lowPrioritySpotPriceFactor = 1.0
     final BigDecimal highPrioritySpotPriceFactor = 1.04
-    final Map<String, String> imageArchToInstanceTypeArch = ImmutableMap.copyOf([x86_64: '64-bit', i386: '32-bit'])
 
     def grailsApplication
     def awsEc2Service
@@ -80,12 +79,6 @@ class InstanceTypeService implements CacheInitializer {
     BigDecimal calculateUrgentLinuxSpotBid(UserContext userContext, String instanceTypeName) {
         InstanceTypeData instanceType = getInstanceType(userContext, instanceTypeName)
         instanceType.linuxOnDemandPrice * highPrioritySpotPriceFactor
-    }
-
-    Collection<InstanceTypeData> findRelevantInstanceTypesForImage(UserContext userContext, Image image) {
-        Collection<InstanceTypeData> instanceTypes = getInstanceTypes(userContext)
-        String instanceTypeArch = imageArchToInstanceTypeArch[image.architecture]
-        instanceTypes.findAll { it.hardwareProfile.architecture.contains(instanceTypeArch) }
     }
 
     InstanceTypeData getInstanceType(UserContext userContext, String instanceTypeName) {

--- a/test/unit/com/netflix/asgard/InstanceTypeServiceTests.groovy
+++ b/test/unit/com/netflix/asgard/InstanceTypeServiceTests.groovy
@@ -107,23 +107,4 @@ class InstanceTypeServiceTests extends GroovyTestCase {
         assert 0.96 == euWestReservedPricing.get(InstanceType.M24xlarge, InstanceProductType.LINUX_UNIX)
         assertNull euWestReservedPricing.get(InstanceType.Cg14xlarge, InstanceProductType.LINUX_UNIX)
     }
-
-    void testFindRelevantInstanceTypesFor64BitImage() {
-        InstanceTypeService instanceTypeService = Mocks.instanceTypeService()
-        Image image = new Image(architecture: 'x86_64')
-        List<String> expected64BitInstanceTypes = ['m3.xlarge', 'm3.2xlarge', 't1.micro', 'm1.small', 'm1.medium',
-                'c1.medium', 'm1.large', 'm2.xlarge', 'm1.xlarge', 'c1.xlarge', 'm2.2xlarge', 'cc1.4xlarge',
-                'm2.4xlarge', 'cg1.4xlarge', 'cc2.8xlarge', 'hi1.4xlarge', 'huge.mainframe']
-
-        assertEquals(expected64BitInstanceTypes,
-                instanceTypeService.findRelevantInstanceTypesForImage(Mocks.userContext(), image)*.name)
-    }
-
-    void testFindRelevantInstanceTypesFor32BitImage() {
-        InstanceTypeService instanceTypeService = Mocks.instanceTypeService()
-        Image image = new Image(architecture: 'i386')
-        List<String> expected32BitInstaceTypes = ['t1.micro', 'm1.small', 'm1.medium', 'c1.medium']
-        assertEquals(expected32BitInstaceTypes,
-            instanceTypeService.findRelevantInstanceTypesForImage(Mocks.userContext(), image)*.name)
-    }
 }


### PR DESCRIPTION
Deleting some old logic that compares architectures between AMIs and
instance types. This complexity is no longer useful, since all Amazon
instance types now support x86_64/64-bit architectures, including
m1.small.
