### PR TITLE
ASGARD-1133 - Allow red black with no traffic and no health checks

### DIFF
--- a/grails-app/controllers/com/netflix/asgard/ClusterController.groovy
+++ b/grails-app/controllers/com/netflix/asgard/ClusterController.groovy
@@ -212,7 +212,6 @@ ${lastGroup.loadBalancerNames}"""
             Integer maxSize = maxSizeParam ? maxSizeParam as Integer : lastGroup.maxSize
             InitialTraffic initialTraffic = params.trafficAllowed ? InitialTraffic.ALLOWED : InitialTraffic.PREVENTED
             boolean checkHealth = params.containsKey('checkHealth')
-            boolean discoveryExists = configService.doesRegionalDiscoveryExist(userContext.region)
             String instanceType = params.instanceType ?: lastLaunchConfig.instanceType
             String spotPrice = null
             if (!params.pricing) {


### PR DESCRIPTION
Remove obsolete validation where the user would have previously had to pick either 'ASGARD-1133 Wait for Eureka health check pass' or 'Send client requests to new instances'.
