### PR TITLE
ASGARD-1135 Prevent Firefox usage

### DIFF
--- a/grails-app/conf/TrackingFilters.groovy
+++ b/grails-app/conf/TrackingFilters.groovy
@@ -24,13 +24,25 @@ class TrackingFilters {
             '.*(libcurl|Python-urllib|Wget|HttpClient|lwp-request|Java).*')
 
     static filters = {
-        all(controller: '*', action: '*') {
+        all(controller: 'firefox', invert: true) {
             before = {
                 Requests.preventCaching(response)
 
                 String userAgent = request.getHeader('user-agent')
                 if (userAgent?.contains('MSIE') && !userAgent.contains('chromeframe')) {
                     request['ieWithoutChromeFrame'] = true
+                }
+
+                // Firefox has a sporadic, critical bug on some complex pages, when there are multiple select elements
+                // with the same name (legal in all other browsers), if the user refreshes the page many times.
+                // For now, disable Firefox use entirely until there is time to build a robust workaround.
+                // Browser sniffing is not a good long-term solution, but denying Firefox use will protect Asgard users
+                // from causing major outages while we build the workaround.
+                // For our purposes, detecting the string "Firefox" is adequate.
+                // See user agent strings at http://www.zytrax.com/tech/web/browser_ids.htm
+                if (userAgent?.contains('Firefox')) {
+                    redirect(controller: 'firefox', action: 'warning')
+                    return false
                 }
 
                 if (!request["originalRequestDump"]) {

--- a/grails-app/controllers/com/netflix/asgard/FirefoxController.groovy
+++ b/grails-app/controllers/com/netflix/asgard/FirefoxController.groovy
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.asgard
+
+/**
+ * Controller for redirect destination page to explain why Firefox is not currently safe to use with Asgard.
+ */
+class FirefoxController {
+
+    def warning() {
+        render '''Please switch to Google Chrome or Safari. You appear to be using Firefox. A critical bug in Firefox
+currently makes it unsafe to use with Asgard. The Firefox bug is sporadic but reproducible. It will take time for the
+Asgard developers to provide a robust solution. In the meantime, please use Google Chrome or Safari for Asgard usage.'''
+    }
+}


### PR DESCRIPTION
There is a critical bug in Firefox on complex pages with many selects
that have the same name attribute. All other browsers behave normally,
but Firefox sporadically fails to mark the initially selected options in a
select element. This can cause deployments to occur without security
groups by accident, which can cause major outages.

Until we have a robust solution in place to work around the Firefox bug,
we are forbidding Firefox use in Asgard, as a safety measure. Users can
still use Chrome or Safari.
