### PR TITLE
ASGARD-1124 - Single EBS volume for m3 instances

### DIFF
--- a/grails-app/services/com/netflix/asgard/AwsAutoScalingService.groovy
+++ b/grails-app/services/com/netflix/asgard/AwsAutoScalingService.groovy
@@ -1064,11 +1064,9 @@ class AwsAutoScalingService implements CacheInitializer, InitializingBean {
             String encodedUserData = Ensure.encoded(userData)
             if (configService.instanceTypeNeedsEbsVolumes(instanceType)) {
                 blockDeviceMappings = blockDeviceMappings ?: []
-                (1..configService.countOfEbsVolumesAddedToLaunchConfigs).inject(blockDeviceMappings) { mappings, i ->
-                    mappings << new BlockDeviceMapping(
-                            deviceName: "/dev/${configService.prefixOfEbsVolumesAddedToLaunchConfigs}${i}",
-                            ebs: new Ebs(volumeSize: configService.sizeOfEbsVolumesAddedToLaunchConfigs))
-                }
+                blockDeviceMappings << new BlockDeviceMapping(
+                        deviceName: "${configService.ebsVolumeDeviceNameForLaunchConfigs}",
+                        ebs: new Ebs(volumeSize: configService.sizeOfEbsVolumesAddedToLaunchConfigs))
             }
             def request = new CreateLaunchConfigurationRequest()
                     .withLaunchConfigurationName(name)

--- a/grails-app/services/com/netflix/asgard/ConfigService.groovy
+++ b/grails-app/services/com/netflix/asgard/ConfigService.groovy
@@ -589,23 +589,16 @@ class ConfigService {
     }
 
     /**
-     * @return The number of EBS volumes added to launch configurations for specific instance types.
-     */
-    int getCountOfEbsVolumesAddedToLaunchConfigs() {
-        grailsApplication.config.cloud?.launchConfig?.ebsVolumes?.count ?: 4
-    }
-
-    /**
      * @return The size of EBS volumes added to launch configurations for specific instance types.
      */
     int getSizeOfEbsVolumesAddedToLaunchConfigs() {
-        grailsApplication.config.cloud?.launchConfig?.ebsVolumes?.size ?: 125
+        grailsApplication.config.cloud?.launchConfig?.ebsVolumes?.size ?: 250
     }
 
     /**
-     * @return The prefix of the device name for EBS volumes added to launch configurations for specific instance types.
+     * @return device name for the single EBS volume added to launch configurations for specific instance types
      */
-    String getPrefixOfEbsVolumesAddedToLaunchConfigs() {
-        grailsApplication.config.cloud?.launchConfig?.ebsVolumes?.prefix ?: 'sdb'
+    String getEbsVolumeDeviceNameForLaunchConfigs() {
+        grailsApplication.config.cloud?.launchConfig?.ebsVolumes?.deviceName ?: '/dev/sdb'
     }
 }


### PR DESCRIPTION
Change Asgard's m3.\* launch behavior to add one block device mapping
/dev/sdb instead of the current four block device mappings.
