### PR TITLE
Write stacktrace.log to a better location

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -29,6 +29,9 @@ log4j = {
                 file: "${logDirectory}/asgard.log",
                 layout: pattern(conversionPattern: '[%d{ISO8601}] [%t] %c{4}    %m%n'),
                 datePattern: "'.'yyyy-MM-dd")
+
+        rollingFile name: "stacktrace", maxFileSize: 1024,
+                file: "${logDirectory}/stacktrace.log"
     }
 
     root {


### PR DESCRIPTION
Configuring Grails to write its stacktrace.log file to the same directory as the Asgard log file to avoid permission exceptions when running in Tomcat on Ubuntu.

Full conversation with Joe here:
https://groups.google.com/forum/?fromgroups=#!topic/asgardusers/3ti8GLisDQ0
