### PR TITLE
ASGARD-1152 - 2nd block device for M3 instance types

### DIFF
--- a/grails-app/services/com/netflix/asgard/AwsAutoScalingService.groovy
+++ b/grails-app/services/com/netflix/asgard/AwsAutoScalingService.groovy
@@ -1064,9 +1064,12 @@ class AwsAutoScalingService implements CacheInitializer, InitializingBean {
             String encodedUserData = Ensure.encoded(userData)
             if (configService.instanceTypeNeedsEbsVolumes(instanceType)) {
                 blockDeviceMappings = blockDeviceMappings ?: []
-                blockDeviceMappings << new BlockDeviceMapping(
-                        deviceName: "${configService.ebsVolumeDeviceNameForLaunchConfigs}",
-                        ebs: new Ebs(volumeSize: configService.sizeOfEbsVolumesAddedToLaunchConfigs))
+                List<String> deviceNames = configService.ebsVolumeDeviceNamesForLaunchConfigs
+                for (deviceName in deviceNames) {
+                    blockDeviceMappings << new BlockDeviceMapping(
+                            deviceName: deviceName,
+                            ebs: new Ebs(volumeSize: configService.sizeOfEbsVolumesAddedToLaunchConfigs))
+                }
             }
             def request = new CreateLaunchConfigurationRequest()
                     .withLaunchConfigurationName(name)

--- a/grails-app/services/com/netflix/asgard/ConfigService.groovy
+++ b/grails-app/services/com/netflix/asgard/ConfigService.groovy
@@ -619,13 +619,13 @@ class ConfigService {
      * @return the size of EBS volumes added to launch configurations for specific instance types
      */
     int getSizeOfEbsVolumesAddedToLaunchConfigs() {
-        grailsApplication.config.cloud?.launchConfig?.ebsVolumes?.size ?: 250
+        grailsApplication.config.cloud?.launchConfig?.ebsVolumes?.size ?: 125
     }
 
     /**
      * @return device name for the single EBS volume added to launch configurations for specific instance types
      */
-    String getEbsVolumeDeviceNameForLaunchConfigs() {
-        grailsApplication.config.cloud?.launchConfig?.ebsVolumes?.deviceName ?: '/dev/sdb'
+    List<String> getEbsVolumeDeviceNamesForLaunchConfigs() {
+        grailsApplication.config.cloud?.launchConfig?.ebsVolumes?.deviceNames ?: ['/dev/sdb', '/dev/sdc']
     }
 }


### PR DESCRIPTION
Needed until a new Base AMI gets released to handle single-device configs better.
