### PR TITLE
ASGARD-1153 - Rolling Push block device mappings

### DIFF
--- a/grails-app/services/com/netflix/asgard/AwsAutoScalingService.groovy
+++ b/grails-app/services/com/netflix/asgard/AwsAutoScalingService.groovy
@@ -1020,7 +1020,7 @@ class AwsAutoScalingService implements CacheInitializer, InitializingBean {
                 createLaunchConfiguration(userContext, launchConfigName, launchConfigTemplate.imageId,
                         launchConfigTemplate.keyName, securityGroups, userData,
                         launchConfigTemplate.instanceType, launchConfigTemplate.kernelId,
-                        launchConfigTemplate.ramdiskId, launchConfigTemplate.iamInstanceProfile, null,
+                        launchConfigTemplate.ramdiskId, launchConfigTemplate.iamInstanceProfile,
                         launchConfigTemplate.spotPrice, launchConfigTemplate.ebsOptimized, task)
                 result.launchConfigCreated = true
             } catch (AmazonServiceException launchConfigCreateException) {
@@ -1054,7 +1054,7 @@ class AwsAutoScalingService implements CacheInitializer, InitializingBean {
 
     void createLaunchConfiguration(UserContext userContext, String name, String imageId, String keyName,
             Collection<String> securityGroups, String userData, String instanceType, String kernelId, String ramdiskId,
-            String iamInstanceProfile, Collection<BlockDeviceMapping> blockDeviceMappings, String spotPrice,
+            String iamInstanceProfile, String spotPrice,
             boolean ebsOptimized = false, Task existingTask = null) {
         taskService.runTask(userContext, "Create Launch Configuration '${name}' with image '${imageId}'", { Task task ->
             Check.notNull(name, LaunchConfiguration, "name")
@@ -1062,8 +1062,8 @@ class AwsAutoScalingService implements CacheInitializer, InitializingBean {
             Check.notNull(keyName, LaunchConfiguration, "keyName")
             Check.notNull(instanceType, LaunchConfiguration, "instanceType")
             String encodedUserData = Ensure.encoded(userData)
+            List<BlockDeviceMapping> blockDeviceMappings = []
             if (configService.instanceTypeNeedsEbsVolumes(instanceType)) {
-                blockDeviceMappings = blockDeviceMappings ?: []
                 List<String> deviceNames = configService.ebsVolumeDeviceNamesForLaunchConfigs
                 for (deviceName in deviceNames) {
                     blockDeviceMappings << new BlockDeviceMapping(

--- a/src/groovy/com/netflix/asgard/push/RollingPushOperation.groovy
+++ b/src/groovy/com/netflix/asgard/push/RollingPushOperation.groovy
@@ -113,7 +113,7 @@ class RollingPushOperation extends AbstractPushOperation {
         awsAutoScalingService.createLaunchConfiguration(options.common.userContext, newLaunchName,
                 options.imageId, options.keyName, securityGroups, userData,
                 options.instanceType, oldLaunch.kernelId, oldLaunch.ramdiskId, iamInstanceProfile,
-                oldLaunch.blockDeviceMappings, options.spotPrice, oldLaunch.ebsOptimized as boolean, task)
+                options.spotPrice, oldLaunch.ebsOptimized as boolean, task)
 
         Time.sleepCancellably 200 // small pause before ASG update to avoid rate limiting
         task.log("Updating group ${groupName} to use launch config ${newLaunchName}")


### PR DESCRIPTION
Just as a Red Black Push completely replaces all Block Device Mappings based on the standard configuration for the new instance type, the Rolling Push should do the same. There is no convenient way for Asgard users to create their own choice of block device mappings anyway.

Even in the case where a power user created a Launch Configuration with the command line and chose their own Block Device Mappings, there is no consistent, reliable, simple algorithm to determine which of those mappings to retain, which ones to delete, and which ones to replace with standard mappings. We're working around Amazon's lack of a proper instance types API, and their lack of automatic helpful behavior for launching m3 instance types.
