### PR TITLE
ASGARD-1166 - MonkeyPatcherService & CacheLoadStartService in BootStrap

### DIFF
--- a/grails-app/conf/BootStrap.groovy
+++ b/grails-app/conf/BootStrap.groovy
@@ -18,8 +18,14 @@ import grails.converters.JSON
 
 class BootStrap {
 
+    /** This "unused" variable needs to be declared here in order to get the referenced service initialized early. */
+    def cacheLoadStartService
+
     def configService
     def initService
+
+    /** This "unused" variable needs to be declared here in order to get the referenced service initialized early. */
+    def monkeyPatcherService
 
     def init = { servletContext ->
         if (configService.appConfigured) { // Only start warming the caches if Asgard has been configured


### PR DESCRIPTION
Now with comments to explain why the "unused" variables need to be declared here, so I won't "clean them up" again later.
