### PR TITLE
ASGARD-1174 - Init screen on Firefox should not do infinite redirects

### DIFF
--- a/grails-app/conf/InitFilters.groovy
+++ b/grails-app/conf/InitFilters.groovy
@@ -20,7 +20,7 @@ class InitFilters {
     def configService
 
     def filters = {
-        all(controller: '(init|server)', invert: true) {
+        all(controller: '(init|server|firefox)', invert: true) {
             before = {
                 if (!configService.appConfigured) {
                     redirect(controller: 'init')

--- a/grails-app/conf/LoadingFilters.groovy
+++ b/grails-app/conf/LoadingFilters.groovy
@@ -22,7 +22,7 @@ class LoadingFilters {
     def initService
 
     def filters = {
-        all(controller: '(cache|init|healthcheck|server)', invert: true) {
+        all(controller: '(cache|init|healthcheck|server|firefox)', invert: true) {
             before = {
                 if (!initService.cachesFilled() && !System.getProperty('skipCacheFill')) {
                     render(status: HttpServletResponse.SC_SERVICE_UNAVAILABLE, view: '/loading')


### PR DESCRIPTION
It also should not show the loading screen when the administrator still hasn't configured Asgard yet.

Instead, Firefox should immediately show the message about why Firefox is currently incompatible.

This is important to fix the initial user experience before we make our first public Asgard AMI.
