### PR TITLE
Asgard version 1.2 update with release notes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,20 @@
+1.2
+
+Features
+- Choose healthiest Eureka nodes, and retry calls
+- Expose ELB "other" policies, read-only for now
+
+Infrastructure
+- Upgrade to CodeNarc 0.18.1
+
+Bug Fixes
+- 404 Not Found response for non-existent DBSnapshot
+- Allow two-letter app names in select2 drop-downs
+- Rolling Push should retain block device mappings
+- Fail scale-up operation if traffic allowed and status not UP
+- New install should show correct warning in Firefox for now
+
+
 1.1.2
 
 Features

--- a/application.properties
+++ b/application.properties
@@ -3,4 +3,4 @@
 app.grails.version=2.1.1
 app.name=asgard
 app.servlet.version=2.4
-app.version=1.1.2
+app.version=1.2


### PR DESCRIPTION
It's time to do an internal release followed by a public release, in order to fix the Firefox init bug before making the public AMI.
