### PR TITLE
fix issue #338: Make devPhase part of groupName

### DIFF
--- a/grails-app/controllers/com/netflix/asgard/GroupCreateCommand.groovy
+++ b/grails-app/controllers/com/netflix/asgard/GroupCreateCommand.groovy
@@ -27,6 +27,7 @@ import grails.validation.Validateable
     String stack
     String newStack
     String detail
+    String devPhase
     String chaosMonkey
     String region
     String imageId
@@ -34,6 +35,15 @@ import grails.validation.Validateable
     boolean appWithClusterOptLevel
 
     static constraints = {
+
+        devPhase(nullable: true, validator: { value, command ->
+            if (value && !Relationships.checkName(value)) {
+                return "devPhase.illegalChar"
+            }
+            if (Relationships.usesReservedFormat(value)) {
+                return "name.usesReservedFormat"
+            }
+        })
 
         appName(nullable: false, blank: false, validator: { value, command ->
             if (!Relationships.checkName(value)) {

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -56,6 +56,8 @@ groupName.exists=There is already an auto scaling group named {3}
 stack.illegalChar=The new stack field must be empty or consist of alphanumeric characters
 stack.matchesNewStack=You cannot use both an existing stack and a new stack
 
+devPhase.illegalChar=DevPhase can only contain letters, numbers, underscores, and dots
+
 name.usesReservedFormat=The format "v###" (where # is any digit) and the format "[a-z]0" (where [a-z] is any letter) are reserved. Please use a different name.
 
 snapshotCommand.volumeSize.matches.error=Volume size must be an integer

--- a/test/unit/com/netflix/asgard/GroupCreateCommandSpec.groovy
+++ b/test/unit/com/netflix/asgard/GroupCreateCommandSpec.groovy
@@ -132,6 +132,23 @@ class GroupCreateCommandSpec extends Specification {
         'blah-v305'   | 'name.usesReservedFormat'
     }
 
+    @Unroll("""should validate devPhase input '#devPhase' with error code '#error'""")
+    def 'devPhase constraints'() {
+        cmd.stack = 'iphone'
+        cmd.devPhase = devPhase
+
+        when:
+        cmd.validate()
+
+        then:
+        cmd.errors.devPhase == error
+
+        where:
+        devPhase      | error
+        'v305'        | 'name.usesReservedFormat'
+        'foo-bar'     | 'devPhase.illegalChar'
+    }
+
     @Unroll("""should validate chaosMonkey input '#chaosMonkey' with error code '#error' when requestedFromGui is \
 '#requestedFromGui' and isChaosMonkeyActive is '#isChaosMonkeyActive' and optLevel is '#optLevel'""")
     def 'chaosMonkey constraints'() {


### PR DESCRIPTION
This small change intends to fix #338. 

What is unclear to me now is why I have two failures in LoadBalancerControllerTests.groovy:

1)
Cannot invoke method getBean() on null object
java.lang.NullPointerException: Cannot invoke method getBean() on null object
    at com.netflix.asgard.LoadBalancerController$_closure5.doCall(LoadBalancerController.groovy:127)
    at com.netflix.asgard.LoadBalancerControllerTests.testSaveWithoutMostParams(LoadBalancerControllerTests.groovy:62)

2)
Cannot invoke method getBean() on null object
java.lang.NullPointerException: Cannot invoke method getBean() on null object
    at com.netflix.asgard.LoadBalancerController$_closure5.doCall(LoadBalancerController.groovy:157)
    at com.netflix.asgard.LoadBalancerControllerTests.testSaveSuccessfully(LoadBalancerControllerTests.groovy:88)

Interestingly, the failure only happens when I run all tests (grails test-app) but not when I run only the LoadBalancerCrontrollerTests, so it looks like there may be an order-dependency somewhere in the tests?
