### PR TITLE
ASGARD-1193 - Stop collecting unlimited host names

### DIFF
--- a/grails-app/conf/TrackingFilters.groovy
+++ b/grails-app/conf/TrackingFilters.groovy
@@ -50,7 +50,6 @@ class TrackingFilters {
                 }
                 if (session.isNew()) {
                     String hostName = Requests.getClientHostName(request)
-                    ServerController.hostNames.add(hostName)
                     if (userAgent && !userAgent.matches(nonBrowserUserAgents)) {
                         log.info "${new DateTime()} Session started. Client ${hostName}, User-Agent ${userAgent}"
                     }

--- a/grails-app/controllers/com/netflix/asgard/ServerController.groovy
+++ b/grails-app/controllers/com/netflix/asgard/ServerController.groovy
@@ -24,7 +24,6 @@ class ServerController {
 
     def serverService
     def taskService
-    static Set<String> hostNames = new TreeSet<String>()
 
     def index = { render InetAddress.localHost.hostName }
 
@@ -50,8 +49,6 @@ class ServerController {
     def waitingToMoveTraffic = { render "${serverService.isThisServerWaitingToMoveTraffic()}" }
 
     def env = { render "${grailsApplication.config.cloud.accountName}" }
-
-    def users = { render hostNames.join("\n") }
 
     def hoursSinceStartup = { render "${serverService.getHoursSinceStartup()}" }
 


### PR DESCRIPTION
Collecting host names in ServerController.hostNames has never turned out to be useful, and it's recently been found to be dangerous when there is a lot of traffic. Delete it from ServerController and from TrackingFilters.
