### PR TITLE
ASGARD-1195 - Update OneLogin Java in preparation for Java 7 migration

### DIFF
--- a/src/java/com/onelogin/saml/Response.java
+++ b/src/java/com/onelogin/saml/Response.java
@@ -98,5 +98,4 @@ public class Response {
         return false;
     }
 
-
 }


### PR DESCRIPTION
Should prevent known error with Onelogin SSO in Java 1.7u25:
com.sun.org.apache.xml.internal.security.utils.resolver.ResourceResolverException: Cannot resolve element with ID pfxfe4a4249-0c4f-2bec-293a-b571bf8d748f
at com.sun.org.apache.xml.internal.security.utils.resolver.implementations.ResolverFragment.engineResolve(ResolverFragment.java:90)
