### PR TITLE
ASGARD-1219 - Fix NullPointerException in /task/show/123doesntexist

### DIFF
--- a/grails-app/controllers/com/netflix/asgard/TaskController.groovy
+++ b/grails-app/controllers/com/netflix/asgard/TaskController.groovy
@@ -62,8 +62,8 @@ class TaskController {
 
     def show = {
         Task task
-        if (params.id) {
-            String id = params.id
+        String id = params.id
+        if (id) {
             task = taskService.getTaskById(id)
         } else {
             String runId = params.runId
@@ -74,11 +74,11 @@ class TaskController {
             List<HistoryEvent> events = awsSimpleWorkflowService.getExecutionHistory(workflowExecution)
             task = Task.fromSwf(workflowExecutionDetail, events)
         }
-        String updateTime = task.updateTime ? Time.format(task.updateTime) : ''
         if (!task) {
             Requests.renderNotFound('Task', id, this)
             return
         } else {
+            String updateTime = task.updateTime ? Time.format(task.updateTime) : ''
             withFormat {
                 html { return [ 'task' : task ] }
                 xml { new XML(task).render(response) }

--- a/test/unit/com/netflix/asgard/TaskControllerSpec.groovy
+++ b/test/unit/com/netflix/asgard/TaskControllerSpec.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.asgard
+
+import grails.test.mixin.TestFor
+import org.apache.http.HttpStatus
+import spock.lang.Specification
+
+@SuppressWarnings("GroovyAssignabilityCheck")
+@TestFor(TaskController)
+class TaskControllerSpec extends Specification {
+
+    void setup() {
+        TestUtils.setUpMockRequest()
+    }
+
+    def 'non-existent task should render a "not found" response'() {
+        controller.taskService = Mock(TaskService) {
+            getTaskById(_) >> null
+        }
+
+        when:
+        controller.params.id = 'nosuchluck'
+        controller.show()
+
+        then:
+        view == '/error/missing'
+        response.status == HttpStatus.SC_NOT_FOUND
+    }
+}


### PR DESCRIPTION
Added unit test for /task/show "not found" case.

The error message won't match logically for the workflowId/runId case, but we plan to remove that case soon anyway.
