### PR TITLE
ASGARD-1222 - Scheduled Action links should be regional

### DIFF
--- a/grails-app/controllers/com/netflix/asgard/ScheduledActionController.groovy
+++ b/grails-app/controllers/com/netflix/asgard/ScheduledActionController.groovy
@@ -17,9 +17,11 @@ package com.netflix.asgard
 
 import com.amazonaws.services.autoscaling.model.AutoScalingGroup
 import com.amazonaws.services.autoscaling.model.ScheduledUpdateGroupAction
+import com.netflix.grails.contextParam.ContextParam
 import grails.converters.JSON
 import grails.converters.XML
 
+@ContextParam('region')
 class ScheduledActionController {
 
     def awsAutoScalingService


### PR DESCRIPTION
For example, the navigation bar link to the list screen should specify the region
