### PR TITLE
ASGARD-1240 - Preserve query params on all login link redirects

### DIFF
--- a/grails-app/conf/com/netflix/asgard/SettingsFilters.groovy
+++ b/grails-app/conf/com/netflix/asgard/SettingsFilters.groovy
@@ -43,6 +43,8 @@ class SettingsFilters {
                 request.apiTokenEnabled = configService.apiTokenEnabled
                 boolean authenticated = SecurityUtils.subject?.authenticated
                 request.requireLoginForEdit = configService.authenticationRequiredForEdit && !authenticated
+                request.targetUri = request.forwardURI + (request.queryString ? "?${request.queryString}" : '')
+
                 // If the last value is falsy and there is no explicit return statement then this filter method will
                 // return a falsy value and cause requests to fail silently.
                 return true

--- a/grails-app/views/cluster/show.gsp
+++ b/grails-app/views/cluster/show.gsp
@@ -191,7 +191,7 @@
             </g:form>
           </g:if>
           <g:else>
-            <g:link controller="auth" action="login" params="${[targetUri: request.forwardURI.encodeAsHTML()]}">
+            <g:link controller="auth" action="login" params="${[targetUri: targetUri]}">
               Login to enable Create Next Group.
             </g:link>
           </g:else>

--- a/grails-app/views/layouts/main.gsp
+++ b/grails-app/views/layouts/main.gsp
@@ -62,7 +62,6 @@
         <input type="text" name="ticket" placeholder="${ticketLabel}" id="ticketNumber" title="${fullTicketLabel} number" class="${ticketRequired ? 'required' : 'optional'}"/>
       </div>
       <g:if test="${authenticationEnabled}">
-        <g:set var='targetUri' value="${request.requestURL + (request.queryString ? '?' + request.queryString : '')}"/>
         <shiro:isLoggedIn>
           <div class="authentication">
             Logged in as <shiro:principal/>


### PR DESCRIPTION
The "Log in to create next group" link on the cluster screen should retain any query parameters such as ?autoDeploy=on when the user gets redirected back to Asgard from OneLogin.
