### PR TITLE
Fix unit test to run locally as well as on Jenkins

### DIFF
--- a/test/unit/com/netflix/asgard/FastPropertyTagLibSpec.groovy
+++ b/test/unit/com/netflix/asgard/FastPropertyTagLibSpec.groovy
@@ -16,7 +16,6 @@
 package com.netflix.asgard
 
 import grails.test.mixin.TestFor
-import org.codehaus.groovy.grails.commons.DefaultGrailsApplication
 import spock.lang.Specification
 
 @TestFor(FastPropsTagLib)


### PR DESCRIPTION
The way I changed this before made it possible for it to fail locally because of our local machines' config files.
