### PR TITLE
ASGARD-1245	- Fix NullPointerException in image/launch

### DIFF
--- a/src/groovy/com/netflix/asgard/NetflixAdvancedUserDataProvider.groovy
+++ b/src/groovy/com/netflix/asgard/NetflixAdvancedUserDataProvider.groovy
@@ -48,11 +48,11 @@ class NetflixAdvancedUserDataProvider implements AdvancedUserDataProvider {
 
         UserContext userContext = launchContext.userContext
         String appNameFromApplication = launchContext.application?.name
-        String groupName = launchContext.autoScalingGroup?.autoScalingGroupName
-        String launchConfigName = launchContext.launchConfiguration?.launchConfigurationName
+        String groupName = launchContext.autoScalingGroup?.autoScalingGroupName ?: ''
+        String launchConfigName = launchContext.launchConfiguration?.launchConfigurationName ?: ''
         Image image = launchContext.image
         String appName = appNameFromApplication ?: Relationships.appNameFromGroupName(groupName) ?:
-            Relationships.packageFromAppVersion(image.appVersion)
+            Relationships.packageFromAppVersion(image.appVersion) ?: ''
 
         // If the AMI's description shows a nflx-base version of 2 or greater, use the simple user data format.
         Matcher matcher = image?.description =~ /.*ancestor_version=nflx-base-([0-9]+)[^0-9].*/

--- a/test/unit/com/netflix/asgard/NetflixAdvancedUserDataProviderSpec.groovy
+++ b/test/unit/com/netflix/asgard/NetflixAdvancedUserDataProviderSpec.groovy
@@ -153,6 +153,20 @@ class NetflixAdvancedUserDataProviderSpec extends Specification {
         'lionhead' | null                                 | null                  | 'lionhead'
     }
 
+    def 'launching an image without the name of a application should not send nulls to user data provider'() {
+
+        UserDataProvider userDataProvider = Mock(UserDataProvider)
+        pluginService = Mock(PluginService) { getUserDataProvider() >> userDataProvider }
+        netflixAdvancedUserDataProvider.pluginService = pluginService
+        launchContext.image = new Image()
+
+        when:
+        netflixAdvancedUserDataProvider.buildUserData(launchContext)
+
+        then: "no null string values sent to plugin"
+        1 * userDataProvider.buildUserDataForVariables(userContext, '', '', '')
+    }
+
     private AutoScalingGroupBeanOptions asg(String name) {
         new AutoScalingGroupBeanOptions(autoScalingGroupName: name)
     }


### PR DESCRIPTION
This enables private user data provider plugins to continue to assert that these optional string inputs are not null, which is good for reducing the chances of accidentally putting the word "null" as an ASG name or app name in a user data string.
