### PR TITLE
Upgrade to glisten-0.3 which has aws-java-sdk-1.6.6

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -82,7 +82,7 @@ grails.project.dependency.resolution = {
 
         compile(
                 // Ease of use library for Amazon Simple Workflow Service (SWF), e.g., WorkflowClientFactory
-                'com.netflix.glisten:glisten:0.2',
+                'com.netflix.glisten:glisten:0.3',
 
                 // Amazon Web Services programmatic interface. Transitive dependency of glisten, but also used directly.
                 'com.amazonaws:aws-java-sdk:1.6.6',


### PR DESCRIPTION
Upgrade to glisten-0.3 which has a version of aws-java-sdk-1.6.6 that matches Asgard’s dependencey
