### PR TITLE
ASGARD 1204 Validate cluster state before auto deploy

### DIFF
--- a/test/unit/com/netflix/asgard/ClusterControllerSpec.groovy
+++ b/test/unit/com/netflix/asgard/ClusterControllerSpec.groovy
@@ -30,6 +30,7 @@ import com.netflix.asgard.push.GroupCreateOperation
 import com.netflix.asgard.push.GroupCreateOptions
 import grails.test.mixin.TestFor
 import spock.lang.Specification
+import spock.lang.Unroll
 
 @SuppressWarnings(["GroovyAssignabilityCheck"])
 @TestFor(ClusterController)
@@ -273,5 +274,66 @@ class ClusterControllerSpec extends Specification {
                 it
             }
         }
+    }
+
+    def 'deploy should fail on an invalid cluster name'() {
+        DeployCommand cmd = Mock(DeployCommand)
+        1 * cmd.hasErrors() >> true
+
+        when:
+        controller.deploy(cmd)
+
+        then:
+        flash.chainModel.cmd == cmd
+        response.redirectedUrl == '/cluster/prepareDeployment'
+    }
+
+    def 'deploy should fail when the cluster has two autoscaling group'() {
+        DeployCommand cmd = new DeployCommand(clusterName: 'helloworld')
+        controller.awsAutoScalingService.getCluster(_, 'helloworld') >> {
+            new Cluster([
+                    AutoScalingGroupData.from(new AutoScalingGroup(autoScalingGroupName: 'helloworld-example-v014',
+                            instances: [new Instance(instanceId: 'i-8ee4eeee')]), [:], [], [:], []),
+                    AutoScalingGroupData.from(new AutoScalingGroup(autoScalingGroupName: 'helloworld-example-v015',
+                            instances: [new Instance(instanceId: 'i-6ef9f30e'), new Instance(instanceId: 'i-95fe1df6')]),
+                            [:], [], [:], [])
+            ])
+        }
+
+        when:
+        controller.deploy(cmd)
+
+        then:
+        flash.message == "Cluster 'helloworld' should only have one ASG to enable automatic deployment."
+        flash.chainModel.cmd == cmd
+        response.redirectedUrl == '/cluster/prepareDeployment/helloworld'
+    }
+
+    @Unroll
+    def 'deploy should fail when the current cluster is not accepting traffic'() {
+        DeployCommand cmd = new DeployCommand(clusterName: 'helloworld')
+        Cluster cluster = Mock(Cluster)
+        AutoScalingGroupData asg = Mock(AutoScalingGroupData)
+        controller.awsAutoScalingService.getCluster(_, 'helloworld') >> cluster
+        cluster.size() >> 1
+        cluster.last() >> asg
+        asg.isLaunchingSuspended() >> launchSuspended
+        asg.isTerminatingSuspended() >> terminateSuspended
+        asg.isAddingToLoadBalancerSuspended() >> addToLoadBalancerSuspended
+
+        when:
+        controller.deploy(cmd)
+
+        then:
+        flash.message == "ASG in cluster 'helloworld' should be receiving traffic to enable automatic deployment."
+        flash.chainModel.cmd == cmd
+        response.redirectedUrl == '/cluster/prepareDeployment/helloworld'
+
+        where:
+        launchSuspended | terminateSuspended | addToLoadBalancerSuspended
+        true            | true               | true
+        true            | false              | false
+        false           | true               | false
+        false           | false              | true
     }
 }


### PR DESCRIPTION
Returns an error if there is more than one ASG in the cluster or if the current ASG has either Launch, Terminate or AddToLoadBalancer disabled.

Needed to change the prepareDeployment action as well since the chain parameter converts integers to Strings. Used the built-in params.int() mechanism in Grails.
