### PR TITLE
Lookup Security Groups by name using filter group-name, for non-default VPCs

### DIFF
--- a/src/groovy/com/netflix/asgard/mock/MockAmazonEC2Client.groovy
+++ b/src/groovy/com/netflix/asgard/mock/MockAmazonEC2Client.groovy
@@ -137,6 +137,7 @@ import com.amazonaws.services.ec2.model.DescribeVpnGatewaysResult
 import com.amazonaws.services.ec2.model.DetachVolumeRequest
 import com.amazonaws.services.ec2.model.DetachVolumeResult
 import com.amazonaws.services.ec2.model.DetachVpnGatewayRequest
+import com.amazonaws.services.ec2.model.Filter
 import com.amazonaws.services.ec2.model.GetConsoleOutputRequest
 import com.amazonaws.services.ec2.model.GetConsoleOutputResult
 import com.amazonaws.services.ec2.model.GetPasswordDataRequest
@@ -461,6 +462,13 @@ class MockAmazonEC2Client extends AmazonEC2Client {
     DescribeSecurityGroupsResult describeSecurityGroups(DescribeSecurityGroupsRequest describeSecurityGroupsRequest) {
 
         List<String> requestedNames = describeSecurityGroupsRequest.groupNames
+        if (requestedNames.size() == 0) {
+            List<Filter> filters = describeSecurityGroupsRequest.getFilters()
+            Filter groupNameFilter = filters.find { it.getName() == 'group-name' }
+            if (groupNameFilter) {
+                requestedNames = groupNameFilter.getValues()
+            }
+        }
 
         Collection<SecurityGroup> securityGroups = mockSecurityGroups
         if (requestedNames.size() >= 1) {


### PR DESCRIPTION
Asgard is unable to find Security Groups in accounts that are EC2-VPC where you're using a non-default VPC.

Issues #336 and #329 refer to a few problems with security groups and multiple VPCs.  This doesn't fix all the issues, (there are still issues when using the same name across VPCs, for instance) but it is a very easy fix to making Asgard work at all with non-default VPCs.

Basically rather than using GroupName with DescribeSecurityGroups, whose behavior varies between EC2-Classic and EC2-VPC, use a filter "group-name" instead.
