### PR TITLE
Methods for getting default VPC subnet IDs

### DIFF
--- a/grails-app/services/com/netflix/asgard/AwsEc2Service.groovy
+++ b/grails-app/services/com/netflix/asgard/AwsEc2Service.groovy
@@ -215,6 +215,19 @@ class AwsEc2Service implements CacheInitializer, InitializingBean {
         Subnets.from(caches.allSubnets.by(userContext.region).list())
     }
 
+    /**
+     * Gets all the subnet ID strings for the subnets in the default VPC of the current account-region. If the
+     * account-region predates VPC then it will not have a default VPC, in which case this method will return an empty
+     * list. It is not possible to have a default VPC with zero subnets.
+     *
+     * @param userContext who, where, why
+     * @return list of identifiers for subnets in default VPC, or empty list if no default VPC exists
+     */
+    List<String> getDefaultVpcSubnetIds(UserContext userContext) {
+        String defaultVpcId = getVpcs(userContext).find { it.isDefault }?.vpcId
+        defaultVpcId ? getSubnets(userContext).findSubnetsByVpc(defaultVpcId).subnetIds : []
+    }
+
     private Collection<Vpc> retrieveVpcs(Region region) {
         awsClient.by(region).describeVpcs().vpcs
     }

--- a/src/groovy/com/netflix/asgard/model/Subnets.groovy
+++ b/src/groovy/com/netflix/asgard/model/Subnets.groovy
@@ -47,6 +47,15 @@ import groovy.transform.Canonical
     }
 
     /**
+     * Gets the identifiers of all the subnets in this set.
+     *
+     * @return the subnet ID strings
+     */
+    List<String> getSubnetIds() {
+        allSubnets*.subnetId
+    }
+
+    /**
      * Simply find a subnet based on its ID.
      *
      * @param id of the subnet
@@ -55,6 +64,17 @@ import groovy.transform.Canonical
     SubnetData findSubnetById(String id) {
         Check.notNull(id, String)
         allSubnets.find { it.subnetId == id }
+    }
+
+    /**
+     * Finds all subnets in a given VPC.
+     *
+     * @param vpcId id of the VPC the subnet belongs to
+     * @return wrapped set of SubnetData representations of subnets associated with the specified VPC
+     */
+    Subnets findSubnetsByVpc(String vpcId) {
+        Check.notNull(vpcId, String)
+        new Subnets(allSubnets.findAll { it.vpcId == vpcId })
     }
 
     /**

--- a/test/unit/com/netflix/asgard/model/SubnetsSpec.groovy
+++ b/test/unit/com/netflix/asgard/model/SubnetsSpec.groovy
@@ -41,6 +41,9 @@ class SubnetsSpec extends Specification {
                 subnet('subnet-e9b0a3a4', 'us-east-1a', 'external', SubnetTarget.ELB),
                 subnet('subnet-c1e8b2b1', 'us-east-1b', 'internal', SubnetTarget.EC2),
                 subnet('subnet-c1e8b2b2', 'us-east-1b', 'external', SubnetTarget.EC2),
+                subnet('subnet-a3770585', 'us-east-1a', null, null, 'vpc-456'),
+                subnet('subnet-a3770586', 'us-east-1b', null, null, 'vpc-456'),
+                subnet('subnet-a3770587', 'us-east-1c', null, null, 'vpc-456'),
         ])
     }
 
@@ -72,6 +75,11 @@ class SubnetsSpec extends Specification {
         expect: expectedSubnets == Subnets.from(awsSubnets).allSubnets
     }
 
+    def 'should get subnet IDs'() {
+        expect: subnets.subnetIds == ['subnet-e9b0a3a1', 'subnet-e9b0a3a2', 'subnet-e9b0a3a3', 'subnet-e9b0a3a4',
+                'subnet-c1e8b2b1', 'subnet-c1e8b2b2', 'subnet-a3770585', 'subnet-a3770586', 'subnet-a3770587']
+    }
+
     def 'should find subnet by ID'() {
         SubnetData expectedSubnet = new SubnetData(subnetId: 'subnet-e9b0a3a1', availabilityZone: 'us-east-1a',
                 purpose: 'internal', target: SubnetTarget.EC2, vpcId: 'vpc-1')
@@ -84,6 +92,20 @@ class SubnetsSpec extends Specification {
 
     def 'should fail when finding subnet by null'() {
         when: subnets.findSubnetById(null)
+        then: thrown(NullPointerException)
+    }
+
+    def 'should find subnets by VPC ID'() {
+        Subnets expectedSubnets = Subnets.from([
+                new Subnet(subnetId: 'subnet-a3770585', availabilityZone: 'us-east-1a', vpcId: 'vpc-456'),
+                new Subnet(subnetId: 'subnet-a3770586', availabilityZone: 'us-east-1a', vpcId: 'vpc-456'),
+                new Subnet(subnetId: 'subnet-a3770587', availabilityZone: 'us-east-1a', vpcId: 'vpc-456'),
+        ])
+        expect: expectedSubnets == subnets.findSubnetsByVpc('vpc-456')
+    }
+
+    def 'should fail when finding subnets by null VPC ID'() {
+        when: subnets.findSubnetsByVpc(null)
         then: thrown(NullPointerException)
     }
 


### PR DESCRIPTION
Precursor methods for fixing Asgard create and update actions for AWS accounts that have a default VPC.
