### PR TITLE
ASGARD-1287 Asgard's single health check should fail if caches are missing during startup but should pass if caches are missing later, after init

### DIFF
--- a/grails-app/controllers/com/netflix/asgard/HealthcheckController.groovy
+++ b/grails-app/controllers/com/netflix/asgard/HealthcheckController.groovy
@@ -20,15 +20,25 @@ class HealthcheckController {
     def healthcheckService
 
     def index() {
-        render 'Healthy'
-    }
-
-    def caches() {
-        if (healthcheckService.isHealthy) {
+        if (healthcheckService.readyForTraffic) {
             render 'Healthy'
         } else {
             response.status = 500
-            render "BROKEN: ${healthcheckService.cacheNamesToProblems}"
+            render 'Not ready traffic. Check cache list or server logs.'
         }
+    }
+
+    /**
+     * This legacy endpoint should be removed after data center traffic switching scripts are no longer calling it.
+     *
+     * The idea was that if we switch traffic back and forth between two machines so they can be alternately bounced
+     * periodically in case of degrading performance over time, then we should avoid sending traffic to a server that
+     * has failed to load its caches. This conservative health check was separated from the regular health check for
+     * the load balancer which needed to send traffic to the server no matter what if we told it to, even if a cache
+     * got out of whack. This is because Asgard is still stateful for now and we can only have one instance serving
+     * general traffic at a time for a given AWS account.
+     */
+    def caches() {
+        index()
     }
 }

--- a/grails-app/services/com/netflix/asgard/ConfigService.groovy
+++ b/grails-app/services/com/netflix/asgard/ConfigService.groovy
@@ -366,13 +366,6 @@ class ConfigService {
     }
 
     /**
-     * @return Map of a property name in {@link Caches} to minimum size for that cache to be considered 'healthy'
-     */
-    Map<String, Integer> getHealthCheckMinimumCounts() {
-        grailsApplication.config.healthCheck?.minimumCounts ?: [:]
-    }
-
-    /**
      * @return true if the current server is meant to be running online to interact with the cloud, false if working
      *          in offline development mode
      */


### PR DESCRIPTION
This change to the health check will enable us to have the desired behavior from ELBs at each of Asgard's lifecycle phases.

During startup, it's important that Asgard fail its health check while loading caches so that ELB traffic will not be directed to a non-ready Asgard.

After cache loading ends, it's important that ELB traffic continue to flow to the single canonical Asgard instance even when Amazon or Asgard has a problem that causes one of the caches to become temporarily empty. If the initial cache loading processes are done OR SKIPPED then the health check should liberally return 200 so traffic is allowed to reach the Asgard instance.

After careful consideration, I realized the existing logic for constantly checking whether the caches were full was not a useful health check for traffic decisions, at least until Asgard is sufficiently stateless that we can run many concurrent identical Asgard instances that all take traffic from the same source. When we get there, we can craft a better health check that regards more than just the default region, and possibly something better than whether a few caches have items in them. For now, we're better off with a load balancer health check that only fails during server initialization.
