### PR TITLE
ASGARD-1292 - Configurable AWS API socket timeout

### DIFF
--- a/grails-app/services/com/netflix/asgard/AwsClientService.groovy
+++ b/grails-app/services/com/netflix/asgard/AwsClientService.groovy
@@ -82,6 +82,7 @@ class AwsClientService implements InitializingBean {
         clientConfiguration = new ClientConfiguration()
         clientConfiguration.proxyHost = configService.proxyHost
         clientConfiguration.proxyPort = configService.proxyPort
+        clientConfiguration.socketTimeout = configService.socketTimeout
         clientConfiguration.userAgent = 'asgard-' + serverService.version
         if (configService.online) {
             providerChain = new AsgardAWSCredentialsProviderChain(configService, restClientService)

--- a/grails-app/services/com/netflix/asgard/ConfigService.groovy
+++ b/grails-app/services/com/netflix/asgard/ConfigService.groovy
@@ -15,6 +15,7 @@
  */
 package com.netflix.asgard
 
+import com.amazonaws.ClientConfiguration
 import com.netflix.asgard.model.InstanceTypeData
 import com.netflix.asgard.server.Environment
 import com.netflix.asgard.text.TextLinkTemplate
@@ -566,6 +567,13 @@ class ConfigService {
      */
     int getHttpConnPoolMaxForRoute() {
         grailsApplication.config.httpConnPool?.maxSize ?: 5
+    }
+
+    /**
+     * @return number of milliseconds
+     */
+    int getSocketTimeout() {
+        grailsApplication.config.cloud?.socketTimeout ?: ClientConfiguration.DEFAULT_SOCKET_TIMEOUT
     }
 
     /**


### PR DESCRIPTION
Asgard prod machines are timing out making certain AWS API calls. Increasing the timeout from the default of 50 seconds to a higher value seems to help, so I'm making the socket timeout configurable.
