### PR TITLE
ASGARD-1293: adds APP_GROUP to user data for instances

### DIFF
--- a/src/groovy/com/netflix/asgard/DefaultUserDataProvider.groovy
+++ b/src/groovy/com/netflix/asgard/DefaultUserDataProvider.groovy
@@ -34,6 +34,7 @@ class DefaultUserDataProvider implements UserDataProvider {
         String result = exportVar('ENVIRONMENT', configService.accountName) +
             exportVar('MONITOR_BUCKET', applicationService.getMonitorBucket(userContext, appName, names.cluster)) +
             exportVar('APP', appName) +
+            exportVar('APP_GROUP', applicationService.getRegisteredApplication(userContext, appName)?.group) +
             exportVar('STACK', names.stack) +
             exportVar('CLUSTER', names.cluster) +
             exportVar('AUTO_SCALE_GROUP', autoScalingGroupName) +

--- a/test/unit/com/netflix/asgard/DefaultUserDataProviderSpec.groovy
+++ b/test/unit/com/netflix/asgard/DefaultUserDataProviderSpec.groovy
@@ -47,6 +47,7 @@ class DefaultUserDataProviderSpec extends Specification {
                 export ENVIRONMENT=
                 export MONITOR_BUCKET=helloworld
                 export APP=helloworld
+                export APP_GROUP=
                 export STACK=example
                 export CLUSTER=helloworld-example
                 export AUTO_SCALE_GROUP=helloworld-example-v345
@@ -65,6 +66,7 @@ class DefaultUserDataProviderSpec extends Specification {
                 export ENVIRONMENT=
                 export MONITOR_BUCKET=helloworld
                 export APP=helloworld
+                export APP_GROUP=
                 export STACK=
                 export CLUSTER=
                 export AUTO_SCALE_GROUP=

--- a/test/unit/com/netflix/asgard/NetflixAdvancedUserDataProviderSpec.groovy
+++ b/test/unit/com/netflix/asgard/NetflixAdvancedUserDataProviderSpec.groovy
@@ -66,6 +66,7 @@ class NetflixAdvancedUserDataProviderSpec extends Specification {
             export NETFLIX_ENVIRONMENT=test
             export NETFLIX_MONITOR_BUCKET=hello
             export NETFLIX_APP=hello
+            export NETFLIX_APP_GROUP=
             export NETFLIX_STACK=dev
             export NETFLIX_CLUSTER=hello-dev
             export NETFLIX_AUTO_SCALE_GROUP=hello-dev-v001
@@ -105,7 +106,8 @@ class NetflixAdvancedUserDataProviderSpec extends Specification {
 
         String description = "blah blah blah, ancestor_version=nflx-base-2.0-12345-h24"
         launchContext.image = new Image(description: description)
-        AppRegistration app = new AppRegistration(name: 'hi', monitorBucketType: MonitorBucketType.byName(type))
+        AppRegistration app = new AppRegistration(name: 'hi', monitorBucketType: MonitorBucketType.byName(type),
+                group: 'hi_group')
         launchContext.application = app
         launchContext.autoScalingGroup = new AutoScalingGroupBeanOptions(autoScalingGroupName: 'hi-dev-v001')
         launchContext.launchConfiguration = new LaunchConfigurationBeanOptions(
@@ -122,6 +124,7 @@ class NetflixAdvancedUserDataProviderSpec extends Specification {
                 export NETFLIX_ENVIRONMENT=test
                 export NETFLIX_MONITOR_BUCKET=${monitorBucket ?: ''}
                 export NETFLIX_APP=hi
+                export NETFLIX_APP_GROUP=hi_group
                 export NETFLIX_STACK=dev
                 export NETFLIX_CLUSTER=hi-dev
                 export NETFLIX_AUTO_SCALE_GROUP=hi-dev-v001
@@ -176,6 +179,7 @@ class NetflixAdvancedUserDataProviderSpec extends Specification {
                 export NETFLIX_ENVIRONMENT=test
                 export NETFLIX_MONITOR_BUCKET=${appEnvVar}
                 export NETFLIX_APP=${appEnvVar}
+                export NETFLIX_APP_GROUP=
                 export NETFLIX_STACK=
                 export NETFLIX_CLUSTER=${asg?.autoScalingGroupName ?: ''}
                 export NETFLIX_AUTO_SCALE_GROUP=${asg?.autoScalingGroupName ?: ''}


### PR DESCRIPTION
req: Demand for Application Group concept in FIT is increasing as more and more Device UI teams are requesting for the same, thoughts on when we can inject the Application Group defined in ASGARD into the application runtime via system properties.
