### PR TITLE
Copy tags from existing to next ASG

### DIFF
--- a/src/groovy/com/netflix/asgard/push/GroupCreateOperation.groovy
+++ b/src/groovy/com/netflix/asgard/push/GroupCreateOperation.groovy
@@ -75,7 +75,9 @@ class GroupCreateOperation extends AbstractPushOperation {
                     withDefaultCooldown(options.defaultCooldown).withHealthCheckType(options.healthCheckType).
                     withHealthCheckGracePeriod(options.healthCheckGracePeriod).
                     withTerminationPolicies(options.terminationPolicies).
-                    withVPCZoneIdentifier(options.vpcZoneIdentifier)
+                    withVPCZoneIdentifier(options.vpcZoneIdentifier).
+                    withTags(options.tags)
+
             LaunchConfiguration launchConfigTemplate = new LaunchConfiguration().withImageId(options.common.imageId).
                     withKernelId(options.kernelId).withInstanceType(options.common.instanceType).
                     withKeyName(options.keyName).withRamdiskId(options.ramdiskId).

--- a/src/groovy/com/netflix/asgard/push/GroupCreateOptions.groovy
+++ b/src/groovy/com/netflix/asgard/push/GroupCreateOptions.groovy
@@ -16,7 +16,9 @@
 package com.netflix.asgard.push
 
 import com.amazonaws.services.autoscaling.model.ScheduledUpdateGroupAction
+import com.amazonaws.services.autoscaling.model.TagDescription
 import com.netflix.asgard.model.ScalingPolicyData
+
 import groovy.transform.Immutable
 
 @Immutable final class GroupCreateOptions {
@@ -35,6 +37,7 @@ import groovy.transform.Immutable
     boolean zoneRebalancingSuspended
     Collection<ScalingPolicyData> scalingPolicies
     Collection<ScheduledUpdateGroupAction> scheduledActions
+    Collection<TagDescription> tags
     String spotPrice
     boolean ebsOptimized
 


### PR DESCRIPTION
This PR causes existing tags assigned to an ASG to be copied when a new ASG is created.  This is useful in cases where tags are assigned to resources outside of Asgard via, say, Cloudformation or the AWS CLI.  

Tags with a key that starts with "aws" are dropped as that key prefix is reserved.