### PR TITLE
ASGARD-1283 Add Eureka client to Asgard and make Asgard register with Eureka service

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -94,7 +94,12 @@ grails.project.dependency.resolution = {
                 // Amazon Web Services programmatic interface. Transitive dependency of glisten, but also used directly.
                 'com.amazonaws:aws-java-sdk:1.7.5',
 
-                // Transitive dependencies of aws-java-sdk, but also used for REST calls, e.g., HttpClient
+                // Enables publication of a health check URL for deploying Asgard, and an on/off switch for activities.
+                // Transitive dependencies include:
+                // rxjava, archaius, ribbon, servo, netflix-commons, netflix-statistics, jersey, guava
+                'com.netflix.eureka:eureka-client:1.1.127',
+
+                // Transitive dependencies of eureka and aws-java-sdk, but also used for REST calls, e.g., HttpClient
                 'org.apache.httpcomponents:httpcore:4.2',
                 'org.apache.httpcomponents:httpclient:4.2.3',
 
@@ -109,7 +114,7 @@ grails.project.dependency.resolution = {
                 'commons-lang:commons-lang:2.4',
 
                 // Easier Java from Joshua Bloch and Google, e.g., Multiset, ImmutableSet, Maps, Table, Splitter
-                'com.google.guava:guava:12.0',
+                'com.google.guava:guava:14.0.1',
 
                 // SSH calls to retrieve secret keys from remote servers, e.g., JSch, ChammelExec
                 'com.jcraft:jsch:0.1.45',

--- a/grails-app/conf/spring/resources.groovy
+++ b/grails-app/conf/spring/resources.groovy
@@ -30,6 +30,7 @@ import com.netflix.asgard.ThreadScheduler
 import com.netflix.asgard.auth.OneLoginAuthenticationProvider
 import com.netflix.asgard.auth.RestrictEditAuthorizationProvider
 import com.netflix.asgard.deployment.DeploymentActivitiesImpl
+import com.netflix.asgard.eureka.EurekaClientHolder
 import com.netflix.asgard.model.CsiScheduledAnalysisFactory
 import groovy.io.FileType
 
@@ -42,6 +43,10 @@ beans = {
     cachedMapBuilder(CachedMapBuilder, ref('threadScheduler'), limitedRegions)
 
     caches(Caches, ref('cachedMapBuilder'), ref('configService'))
+
+    eurekaClientHolder(EurekaClientHolder) {
+        it.autowire = "byName"
+    }
 
     objectMapper(ObjectMapper)
 

--- a/grails-app/services/com/netflix/asgard/ConfigService.groovy
+++ b/grails-app/services/com/netflix/asgard/ConfigService.groovy
@@ -204,6 +204,80 @@ class ConfigService {
     }
 
     /**
+     * Gets the port on which an Asgard instance is serving traffic directly.
+     * <p>
+     * This is useful for cases like constructing a health check URL to report to Eureka Server, because checking the
+     * health of a server is a case where the specific instance needs to accessed directly instead of through an
+     * external router or load balancer.
+     *
+     * @return the port that other systems should use when calling an Asgard instance directly, defaulting to 80
+     */
+    Integer getLocalInstancePort() {
+        grailsApplication.config.server?.localInstancePort ?: 80
+    }
+
+    /**
+     * Gets the URL to use for Eureka Client to register with Eureka Service if the availability zone where the system
+     * is currently running does not have a zone entry anywhere in the values of regionToEurekaServiceAvailabilityZones.
+     *
+     * Example output:
+     * http://us-west-1.discoverytest.example.com:7001/eureka/v2/
+     *
+     * @return the default Eureka Service URL for Eureka Client to register with if no zone-specific matches exist
+     */
+    String getEurekaDefaultRegistrationUrl() {
+        grailsApplication.config.eureka?.defaultRegistrationUrl ?: null
+    }
+
+    /**
+     * Example output:
+     * <pre>
+     * {@code
+     * [
+     *     'us-east-1': ['us-east-1a', 'us-east-1c', 'us-east-1d', 'us-east-1e'],
+     *     'us-west-1': ['us-west-1a', 'us-west-1b', 'us-west-1c'],
+     *     'us-west-2': ['us-west-2a', 'us-west-2b', 'us-west-2c'],
+     *     'eu-west-1': ['eu-west-1a', 'eu-west-1b', 'us-west-1c'],
+     * ]
+     * }
+     * </pre>
+     *
+     * @return a map of region names like 'us-west-1' to list of availability zones in that region where Eureka service
+     *          is running, such as ['us-west-1a', 'us-west-1b']
+     */
+    Map<String, List<String>> getEurekaZoneListsByRegion() {
+        grailsApplication.config.eureka?.zoneListsByRegion ?: [:]
+    }
+
+    /**
+     * Gets the template string for constructing a URL to access Eureka Server from Eureka Client. If the template
+     * contains any of the following strings they will be replaced by the availability zone, region, or environment name
+     * of a Eureka Server node.
+     * <p>
+     * <pre>
+     * {@code
+     *
+     * ${zone} - the availability zone listed as a value for a region in the {@link #getEurekaZoneListsByRegion} map
+     * ${region} - the region listed as a key for the zone in the {@link #getEurekaZoneListsByRegion} map
+     * ${env} - the environment name from {@link #getAccountName}
+     *
+     * Examples:
+     * http://${zone}.${region}.eureka{env}.example:7001/eureka/v2/
+     * http://${region}.eureka{env}.example:7001/eureka/v2/
+     * http://eureka.example:7001/eureka/v2/
+     *
+     * }
+     * </pre>
+     * <p>
+     *
+     * @see com.netflix.asgard.eureka.AsgardEurekaClientConfig#getEurekaServerServiceUrls
+     * @return the configured template for constructing a Eureka Server endpoint
+     */
+    String getEurekaUrlTemplateForZoneRegionEnv() {
+        grailsApplication.config.eureka?.urlTemplateForZoneRegionEnv ?: null
+    }
+
+    /**
      * @return the short label that should be displayed in reference to the change control ticket for cloud changes
      */
     String getTicketLabel() {

--- a/grails-app/services/com/netflix/asgard/EnvironmentService.groovy
+++ b/grails-app/services/com/netflix/asgard/EnvironmentService.groovy
@@ -34,10 +34,31 @@ class EnvironmentService {
     }
 
     /**
-     * @return the instance ID of the current runtime, or throws an exception if not running in the cloud
+     * @return the instance ID of the current runtime, or null if not running in the AWS cloud
      */
     String getInstanceId() {
         EC2MetadataUtils.instanceId
+    }
+
+    /**
+     * Parses the name of the availability zone where the system is running, and truncates the last character to convert
+     * a zone like us-west-1b to us-west-1. This assumes that Amazon will continue to follow their current naming
+     * pattern for zones and regions, where the zone name is always a region name followed by a single letter. If that
+     * pattern changes, we'll need a different approach such as an environment variable, although that has a different
+     * set of tenuous assumptions.
+     *
+     * @return the region where the current system is running, or null if not running in the AWS cloud
+     */
+    String getRegion() {
+        String zone = EC2MetadataUtils.availabilityZone
+        return zone ? zone[0..-2] : null
+    }
+
+    /**
+     * @return the availability zone where the current system is running, or null if not running in the AWS cloud
+     */
+    String getAvailabilityZone() {
+        EC2MetadataUtils.availabilityZone
     }
 
     /**

--- a/src/groovy/com/netflix/asgard/eureka/AsgardCloudEurekaInstanceConfig.groovy
+++ b/src/groovy/com/netflix/asgard/eureka/AsgardCloudEurekaInstanceConfig.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.asgard.eureka
+
+import com.netflix.appinfo.CloudInstanceConfig
+
+/**
+ * {@link com.netflix.appinfo.EurekaInstanceConfig} configuration for Asgard when running in the AWS cloud.
+ *
+ * Unfortunately this class is unusually difficult to unit test because of the test-unfriendly constructor behavior of
+ * the superclass from eureka-client.
+ */
+class AsgardCloudEurekaInstanceConfig extends CloudInstanceConfig {
+
+    int nonSecurePort
+
+    @Override
+    String getAppname() { 'asgard' }
+
+    @Override
+    int getNonSecurePort() {
+        nonSecurePort ?: super.nonSecurePort
+    }
+}

--- a/src/groovy/com/netflix/asgard/eureka/AsgardDataCenterEurekaInstanceConfig.groovy
+++ b/src/groovy/com/netflix/asgard/eureka/AsgardDataCenterEurekaInstanceConfig.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.asgard.eureka
+
+import com.netflix.appinfo.MyDataCenterInstanceConfig
+
+/**
+ * {@link com.netflix.appinfo.EurekaInstanceConfig} configuration for Asgard when running outside the AWS cloud.
+ */
+class AsgardDataCenterEurekaInstanceConfig extends MyDataCenterInstanceConfig {
+
+    @Override
+    String getAppname() { 'asgard' }
+}

--- a/src/groovy/com/netflix/asgard/eureka/AsgardEurekaClientConfig.groovy
+++ b/src/groovy/com/netflix/asgard/eureka/AsgardEurekaClientConfig.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.asgard.eureka
+
+import com.netflix.discovery.DefaultEurekaClientConfig
+import groovy.transform.Canonical
+import org.apache.commons.logging.LogFactory
+
+/**
+ * Enables Eureka Client configuration values to originate from ConfigService instead of from properties files on the
+ * classpath.
+ */
+@Canonical class AsgardEurekaClientConfig extends DefaultEurekaClientConfig {
+
+    private static final log = LogFactory.getLog(this)
+
+    String env
+    String region
+    String eurekaDefaultRegistrationUrl
+    Map<String, List<String>> eurekaZoneListsByRegion
+    String eurekaUrlTemplate
+
+    @Override String[] getAvailabilityZones(String region) {
+        eurekaZoneListsByRegion[region] as String[]
+    }
+
+    @Override List<String> getEurekaServerServiceUrls(String myZone) {
+        log.debug "Looking up Eureka server service URL for availability zone ${myZone}"
+        List<String> urls
+        Map.Entry<String, List<String>> regionToZones = eurekaZoneListsByRegion.find { k, v -> v.contains myZone }
+        if (regionToZones) {
+            String region = regionToZones.key
+            urls = [eurekaUrlTemplate.replace('${zone}', myZone).replace('${region}', region).replace('${env}', env)]
+        } else {
+            urls = eurekaDefaultRegistrationUrl ? [eurekaDefaultRegistrationUrl] : null
+        }
+        log.debug "Using Eureka server service URLs ${urls}"
+        urls
+    }
+
+    @Override String getRegion() { region }
+}

--- a/src/groovy/com/netflix/asgard/eureka/EurekaClientHolder.groovy
+++ b/src/groovy/com/netflix/asgard/eureka/EurekaClientHolder.groovy
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.asgard.eureka
+
+import com.netflix.appinfo.ApplicationInfoManager
+import com.netflix.appinfo.EurekaInstanceConfig
+import com.netflix.appinfo.InstanceInfo.InstanceStatus
+import com.netflix.asgard.ConfigService
+import com.netflix.asgard.EnvironmentService
+import com.netflix.asgard.HealthcheckService
+import com.netflix.discovery.DiscoveryManager
+import com.netflix.discovery.EurekaClientConfig
+import org.springframework.beans.factory.InitializingBean
+
+/**
+ * Initializes Eureka Client (if configured) so that Asgard can register with Eureka Service.
+ */
+class EurekaClientHolder implements InitializingBean {
+
+    ConfigService configService
+    EnvironmentService environmentService
+    DiscoveryManager discoveryManager
+    HealthcheckService healthcheckService
+
+    @Override
+    void afterPropertiesSet() throws Exception {
+        if (configService.eurekaDefaultRegistrationUrl && configService.eurekaZoneListsByRegion &&
+                configService.eurekaUrlTemplateForZoneRegionEnv) {
+            initDiscoveryManager()
+            registerHealthcheckCallback()
+        }
+    }
+
+    /**
+     * The name under which to register the health check callback that will update the Eureka status when system is
+     * ready for traffic.
+     */
+    final String healthcheckCallbackName = 'EurekaStatusUpdate'
+
+    /**
+     * The callback that should run after each time the local health check runs, to change the Eureka status from
+     * STARTING to UP as soon as the system is ready for traffic.
+     */
+    final Closure healthcheckCallback = { Boolean wasHealthyLastTime, Boolean isHealthyNow ->
+        if (isHealthyNow && ApplicationInfoManager.instance.info.status == InstanceStatus.STARTING) {
+            ApplicationInfoManager.instance.instanceStatus = InstanceStatus.UP
+        }
+    }
+
+    /**
+     * Ensures that the DiscoveryManager singleton exists and is stored in holder, then initializes it with Asgard's
+     * implementations of the Eureka config objects.
+     */
+    void initDiscoveryManager() {
+        discoveryManager = DiscoveryManager.instance
+        discoveryManager.initComponent(createEurekaInstanceConfig(), createEurekaClientConfig())
+    }
+
+    /**
+     * When Asgard becomes healthy during Eureka instance status STARTING, change instance status to UP.
+     */
+    void registerHealthcheckCallback() {
+        healthcheckService.registerCallback(healthcheckCallbackName, healthcheckCallback)
+    }
+
+    /**
+     * @return a configured EurekaClientConfig implementation for Asgard to use when initializing
+     *          com.netflix.discovery.DiscoveryManager
+     */
+    EurekaClientConfig createEurekaClientConfig() {
+        new AsgardEurekaClientConfig(
+                env: configService.accountName,
+                region: environmentService.region,
+                eurekaDefaultRegistrationUrl: configService.eurekaDefaultRegistrationUrl,
+                eurekaZoneListsByRegion: configService.eurekaZoneListsByRegion,
+                eurekaUrlTemplate: configService.eurekaUrlTemplateForZoneRegionEnv
+        )
+    }
+
+    /**
+     * @return a configured EurekaInstanceConfig implementation for Asgard to use when initializing
+     *          com.netflix.discovery.DiscoveryManager
+     */
+    EurekaInstanceConfig createEurekaInstanceConfig() {
+        if (environmentService.instanceId) {
+            return new AsgardCloudEurekaInstanceConfig(nonSecurePort: configService.localInstancePort)
+        } else {
+            return new AsgardDataCenterEurekaInstanceConfig()
+        }
+    }
+}

--- a/test/unit/com/netflix/asgard/EnvironmentServiceSpec.groovy
+++ b/test/unit/com/netflix/asgard/EnvironmentServiceSpec.groovy
@@ -33,4 +33,23 @@ class EnvironmentServiceSpec extends Specification {
         expect:
         new EnvironmentService().instanceId == 'i-deadbeef'
     }
+
+    void 'should get the availability zone of the current system from AWS helper class'() {
+        EC2MetadataUtils.metaClass.static.getAvailabilityZone = { 'us-west-1a' }
+
+        expect:
+        new EnvironmentService().availabilityZone == 'us-west-1a'
+    }
+
+    void 'should get the region of the current system based on the availability zone from AWS helper class'() {
+        EC2MetadataUtils.metaClass.static.getAvailabilityZone = { zone }
+
+        expect:
+        new EnvironmentService().region == region
+
+        where:
+        zone         | region
+        'us-west-1a' | 'us-west-1'
+        null         | null
+    }
 }

--- a/test/unit/com/netflix/asgard/eureka/AsgardDataCenterEurekaInstanceConfigSpec.groovy
+++ b/test/unit/com/netflix/asgard/eureka/AsgardDataCenterEurekaInstanceConfigSpec.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.asgard.eureka
+
+import spock.lang.Specification
+
+/**
+ * Tests for AsgardDataCenterEurekaInstanceConfig.
+ */
+class AsgardDataCenterEurekaInstanceConfigSpec extends Specification {
+
+    void 'should return asgard as the app name'() {
+        expect:
+        new AsgardDataCenterEurekaInstanceConfig().appname == 'asgard'
+    }
+}

--- a/test/unit/com/netflix/asgard/eureka/AsgardEurekaClientConfigSpec.groovy
+++ b/test/unit/com/netflix/asgard/eureka/AsgardEurekaClientConfigSpec.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.asgard.eureka
+
+import spock.lang.Specification
+
+/**
+ * Tests for AsgardEurekaClientConfig.
+ */
+class AsgardEurekaClientConfigSpec extends Specification {
+
+    AsgardEurekaClientConfig asgardEurekaClientConfig = new AsgardEurekaClientConfig(
+            env: 'test',
+            eurekaZoneListsByRegion: [
+                    'us-east-1': ['us-east-1a', 'us-east-1c', 'us-east-1d', 'us-east-1e'],
+                    'us-west-1': ['us-west-1a', 'us-west-1b', 'us-west-1c'],
+                    'us-west-2': ['us-west-2a', 'us-west-2b', 'us-west-2c'],
+                    'eu-west-1': ['eu-west-1a', 'eu-west-1b', 'us-west-1c'],
+            ],
+            eurekaUrlTemplate: 'http://${zone}.${region}.eureka${env}.example.com:9004/eureka/v2/',
+    )
+
+    void 'should get availability zones for region based on eurekaZoneListsByRegion'() {
+
+        when:
+        List<String> zones = asgardEurekaClientConfig.getAvailabilityZones('us-west-1') as List
+
+        then:
+        zones == ['us-west-1a', 'us-west-1b', 'us-west-1c']
+    }
+
+    void 'should get injected region'() {
+        expect:
+        new AsgardEurekaClientConfig(region: 'us-west-1').getRegion() == 'us-west-1'
+    }
+
+    void 'should get Eureka server service URLs for a zone'() {
+
+        when:
+        asgardEurekaClientConfig.eurekaDefaultRegistrationUrl = defaultUrl
+        List<String> result = asgardEurekaClientConfig.getEurekaServerServiceUrls(zone)
+
+        then:
+        result == urls
+
+        where:
+        zone         | defaultUrl               | urls
+        'us-west-1c' | 'http://example.com/v2/' | ['http://us-west-1c.us-west-1.eurekatest.example.com:9004/eureka/v2/']
+        'us-west-1a' | 'http://example.com/v2/' | ['http://us-west-1a.us-west-1.eurekatest.example.com:9004/eureka/v2/']
+        'sa-east-1a' | 'http://example.com/v2/' | ['http://example.com/v2/']
+        'sa-east-1a' | null                     | null
+    }
+}

--- a/test/unit/com/netflix/asgard/eureka/EurekaClientHolderSpec.groovy
+++ b/test/unit/com/netflix/asgard/eureka/EurekaClientHolderSpec.groovy
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.asgard.eureka
+
+import com.netflix.appinfo.ApplicationInfoManager
+import com.netflix.appinfo.EurekaInstanceConfig
+import com.netflix.appinfo.InstanceInfo
+import com.netflix.appinfo.InstanceInfo.InstanceStatus
+import com.netflix.asgard.ConfigService
+import com.netflix.asgard.EnvironmentService
+import com.netflix.asgard.HealthcheckService
+import com.netflix.asgard.ServerService
+import com.netflix.discovery.EurekaClientConfig
+import spock.lang.Specification
+
+/**
+ * Tests for EurekaClientHolder.
+ */
+@SuppressWarnings("GroovyAssignabilityCheck")
+class EurekaClientHolderSpec extends Specification {
+
+    ConfigService configService = Mock(ConfigService)
+    EnvironmentService environmentService = Mock(EnvironmentService)
+    ServerService serverService = Mock(ServerService)
+    HealthcheckService healthcheckService = new HealthcheckService(serverService: serverService)
+    EurekaClientHolder eurekaClientHolder = new EurekaClientHolder(configService: configService,
+            environmentService: environmentService, healthcheckService: healthcheckService)
+
+    void 'should initialize Eureka Client only if fully configured'() {
+        EurekaClientHolder eurekaClientHolder = Spy(EurekaClientHolder)
+        eurekaClientHolder.configService = configService
+        eurekaClientHolder.healthcheckService = healthcheckService
+        eurekaClientHolder.createEurekaClientConfig() >> null
+        eurekaClientHolder.createEurekaInstanceConfig() >> null
+
+        when:
+        eurekaClientHolder.afterPropertiesSet()
+
+        then:
+        configService.eurekaDefaultRegistrationUrl >> defaultUrl
+        configService.eurekaZoneListsByRegion >> zonesByRegion
+        configService.eurekaUrlTemplateForZoneRegionEnv >> template
+        count * eurekaClientHolder.initDiscoveryManager() >> { }
+
+        where:
+        count | defaultUrl             | zonesByRegion                 | template
+        1     | 'http://eurekadefault' | ['us-west-1': ['us-west-1a']] | 'http://${zone}.eureka.example.com/eureka/v2'
+        0     | ''                     | ['us-west-1': ['us-west-1a']] | 'http://${zone}.eureka.example.com/eureka/v2'
+        0     | null                   | ['us-west-1': ['us-west-1a']] | 'http://${zone}.eureka.example.com/eureka/v2'
+        0     | 'http://eurekadefault' | [:]                           | 'http://${zone}.eureka.example.com/eureka/v2'
+        0     | 'http://eurekadefault' | null                          | 'http://${zone}.eureka.example.com/eureka/v2'
+        0     | 'http://eurekadefault' | ['us-west-1': ['us-west-1a']] | ''
+        0     | 'http://eurekadefault' | ['us-west-1': ['us-west-1a']] | null
+    }
+
+    void 'should create a EurekaClientConfig'() {
+
+        Map<String, ArrayList<String>> zoneListsByRegion = [
+                'us-east-1': ['us-east-1a', 'us-east-1c', 'us-east-1d', 'us-east-1e'],
+                'us-west-1': ['us-west-1a', 'us-west-1b', 'us-west-1c'],
+                'us-west-2': ['us-west-2a', 'us-west-2b', 'us-west-2c'],
+                'eu-west-1': ['eu-west-1a', 'eu-west-1b', 'us-west-1c'],
+        ]
+
+        when:
+        EurekaClientConfig eurekaClientConfig = eurekaClientHolder.createEurekaClientConfig()
+
+        then:
+        1 * configService.accountName >> 'test'
+        1 * environmentService.region >> 'us-west-1'
+        1 * configService.eurekaDefaultRegistrationUrl >> 'http://example.com'
+        1 * configService.eurekaZoneListsByRegion >> zoneListsByRegion
+        1 * configService.eurekaUrlTemplateForZoneRegionEnv >> 'http://${zone}.${region}.${env}.example.com'
+        0 * _
+        eurekaClientConfig == new AsgardEurekaClientConfig(
+                env: 'test',
+                region: 'us-west-1',
+                eurekaDefaultRegistrationUrl: 'http://example.com',
+                eurekaZoneListsByRegion: zoneListsByRegion,
+                eurekaUrlTemplate: 'http://${zone}.${region}.${env}.example.com')
+    }
+
+    void 'should create a EurekaInstanceConfig outside the cloud'() {
+
+        when:
+        EurekaInstanceConfig eurekaInstanceConfig = eurekaClientHolder.createEurekaInstanceConfig()
+
+        then:
+        1 * environmentService.instanceId >> null
+        0 * _
+        eurekaInstanceConfig instanceof AsgardDataCenterEurekaInstanceConfig
+        eurekaInstanceConfig.appname == 'asgard'
+    }
+
+    void 'should change instance status from STARTING to UP when health check starts to pass'() {
+
+        InstanceInfo instanceInfo = Mock(InstanceInfo)
+        ApplicationInfoManager applicationInfoManager = Mock(ApplicationInfoManager)
+        ApplicationInfoManager.metaClass.static.getInstance = { applicationInfoManager }
+
+        when: 'health check occurs before callback has been registered'
+        healthcheckService.checkHealthAndInvokeCallbacks()
+
+        then: 'health gets checked but no callbacks are registered so no callbacks execute'
+        1 * serverService.shouldCacheLoadingBlockUserRequests() >> true
+        healthcheckService.callbackNamesToCallbacks == [:]
+        0 * _
+
+        when: 'health check callback gets registered and the health check runs and callbacks get invoked'
+        eurekaClientHolder.registerHealthcheckCallback()
+        healthcheckService.checkHealthAndInvokeCallbacks()
+
+        then: 'callback is registered but if health check fails then callback does nothing'
+        healthcheckService.callbackNamesToCallbacks == ['EurekaStatusUpdate': eurekaClientHolder.healthcheckCallback]
+        1 * serverService.shouldCacheLoadingBlockUserRequests() >> true
+        !healthcheckService.readyForTraffic
+        0 * _
+
+        when: 'health check runs again but this time it passes and Eureka status is STARTING'
+        healthcheckService.checkHealthAndInvokeCallbacks()
+
+        then: 'Eureka status changes to UP'
+        1 * serverService.shouldCacheLoadingBlockUserRequests() >> false
+        healthcheckService.readyForTraffic
+        1 * applicationInfoManager.info >> instanceInfo
+        1 * instanceInfo.status >> 'STARTING'
+        1 * applicationInfoManager.setInstanceStatus(InstanceStatus.UP)
+        0 * _
+    }
+}


### PR DESCRIPTION
This will allow Asgard to check for instance health of a new Asgard instance during a deployment of Asgard. Without this, it would be clumsier to write a script that waits for a new Asgard instance to become healthy before starting the withering process on the old Asgard instance.

In addition, this change should satisfy Conformity Monkey conventions. It will also open the door for us to add future enhancements to our workflow processing, where we use the Eureka status of an Asgard instance as a runtime switch to turn workflow processing behavior on and off.
