### PR TITLE
ASGARD-1302 Publish explicit Eureka VIP address

### DIFF
--- a/grails-app/services/com/netflix/asgard/ConfigService.groovy
+++ b/grails-app/services/com/netflix/asgard/ConfigService.groovy
@@ -217,6 +217,21 @@ class ConfigService {
     }
 
     /**
+     * Gets the virtual host name, or "virtual IP" or "VIP", that the system should use to override the default virtual
+     * host name in Eureka client when registering with Eureka service.
+     *
+     * It's common for the VIP to be in the form <name>:<port> such as
+     * asgard-prod:7001
+     *
+     * @return the virtual host name override to use, or null if not configured
+     * @see com.netflix.asgard.eureka.EurekaClientHolder#createEurekaInstanceConfig()
+     * @see com.netflix.appinfo.EurekaInstanceConfig#getVirtualHostName()
+     */
+    String getLocalVirtualHostName() {
+        grailsApplication.config.eureka?.localVirtualHostName ?: null
+    }
+
+    /**
      * Gets the URL to use for Eureka Client to register with Eureka Service if the availability zone where the system
      * is currently running does not have a zone entry anywhere in the values of regionToEurekaServiceAvailabilityZones.
      *

--- a/src/groovy/com/netflix/asgard/eureka/AsgardCloudEurekaInstanceConfig.groovy
+++ b/src/groovy/com/netflix/asgard/eureka/AsgardCloudEurekaInstanceConfig.groovy
@@ -25,7 +25,15 @@ import com.netflix.appinfo.CloudInstanceConfig
  */
 class AsgardCloudEurekaInstanceConfig extends CloudInstanceConfig {
 
+    /**
+     * @see com.netflix.appinfo.EurekaInstanceConfig#getNonSecurePort()
+     */
     int nonSecurePort
+
+    /**
+     * @see com.netflix.appinfo.EurekaInstanceConfig#getVirtualHostName()
+     */
+    String virtualHostName
 
     @Override
     String getAppname() { 'asgard' }
@@ -33,5 +41,10 @@ class AsgardCloudEurekaInstanceConfig extends CloudInstanceConfig {
     @Override
     int getNonSecurePort() {
         nonSecurePort ?: super.nonSecurePort
+    }
+
+    @Override
+    String getVirtualHostName() {
+        virtualHostName ?: super.virtualHostName
     }
 }

--- a/src/groovy/com/netflix/asgard/eureka/EurekaClientHolder.groovy
+++ b/src/groovy/com/netflix/asgard/eureka/EurekaClientHolder.groovy
@@ -96,7 +96,9 @@ class EurekaClientHolder implements InitializingBean {
      */
     EurekaInstanceConfig createEurekaInstanceConfig() {
         if (environmentService.instanceId) {
-            return new AsgardCloudEurekaInstanceConfig(nonSecurePort: configService.localInstancePort)
+            String virtualHostName = configService.localVirtualHostName
+            Integer nonSecurePort = configService.localInstancePort
+            return new AsgardCloudEurekaInstanceConfig(nonSecurePort: nonSecurePort, virtualHostName: virtualHostName)
         } else {
             return new AsgardDataCenterEurekaInstanceConfig()
         }


### PR DESCRIPTION
This will make it possible for people to make calls to Asgard in the cloud using Ribbon and Eureka instead of relying solely on DNS and ELBs.

Unfortunately, the behavior of the constructors in parent classes in eureka client makes it difficult or impossible to unit test this change without first rewriting eureka client to be more test-friendly.
