### PR TITLE
Remove Block Device Mappings from new Launch Config.

### DIFF
--- a/grails-app/controllers/com/netflix/asgard/DeploymentController.groovy
+++ b/grails-app/controllers/com/netflix/asgard/DeploymentController.groovy
@@ -158,6 +158,7 @@ class DeploymentController {
             iamInstanceProfile = iamInstanceProfile ?: configService.defaultIamRole
             instanceMonitoringIsEnabled = instanceMonitoringIsEnabled != null ? instanceMonitoringIsEnabled :
                     configService.enableInstanceMonitoring
+            blockDeviceMappings = null // SWF can not handle serializing this, and Asgard builds them per instance type.
         }
 
         Map<String, Object> attributes = [


### PR DESCRIPTION
Asgard will recreate what should be there based on instance type.
AWS SWF is having trouble serializing these AWS classes.
