### PR TITLE
Allow int parameters with the value "0" in ClusterController

### DIFF
--- a/grails-app/controllers/com/netflix/asgard/ClusterController.groovy
+++ b/grails-app/controllers/com/netflix/asgard/ClusterController.groovy
@@ -20,6 +20,7 @@ import com.amazonaws.services.autoscaling.model.LaunchConfiguration
 import com.amazonaws.services.autoscaling.model.ScheduledUpdateGroupAction
 import com.amazonaws.services.ec2.model.AvailabilityZone
 import com.amazonaws.services.elasticloadbalancing.model.LoadBalancerDescription
+import com.google.common.annotations.VisibleForTesting
 import com.netflix.asgard.model.AutoScalingGroupData
 import com.netflix.asgard.model.AutoScalingProcessType
 import com.netflix.asgard.model.InstancePriceType
@@ -37,6 +38,7 @@ import com.netflix.asgard.push.InitialTraffic
 import com.netflix.grails.contextParam.ContextParam
 import grails.converters.JSON
 import grails.converters.XML
+import groovy.transform.PackageScope
 
 @ContextParam('region')
 class ClusterController {
@@ -292,8 +294,10 @@ Group: ${loadBalancerNames}"""
         }
     }
 
-    private int convertToIntOrUseDefault(String value, Integer defaultValue) {
-        value?.toInteger() ?: defaultValue
+    @VisibleForTesting
+    @PackageScope
+    int convertToIntOrUseDefault(String value, Integer defaultValue) {
+        value?.isInteger() ? value.toInteger() : defaultValue
     }
 
     private boolean shouldAzRebalanceBeSuspended(String azRebalance, boolean lastRebalanceSuspended) {

--- a/test/unit/com/netflix/asgard/ClusterControllerSpec.groovy
+++ b/test/unit/com/netflix/asgard/ClusterControllerSpec.groovy
@@ -30,6 +30,7 @@ import com.netflix.asgard.push.GroupCreateOperation
 import com.netflix.asgard.push.GroupCreateOptions
 import grails.test.mixin.TestFor
 import spock.lang.Specification
+import spock.lang.Unroll
 
 @SuppressWarnings(["GroovyAssignabilityCheck"])
 @TestFor(ClusterController)
@@ -218,6 +219,23 @@ class ClusterControllerSpec extends Specification {
                 it
             }
         }
+    }
+
+    @Unroll
+    def 'integer conversion should allow any valid integer'(String toConvert, Integer defaultValue, Integer expected) {
+        expect:
+        controller.convertToIntOrUseDefault(toConvert, defaultValue) == expected
+
+        where:
+        toConvert | defaultValue | expected
+        "nonInt"  | 100          | 100
+        "1"       | 100          | 1
+        "0"       | 100          | 0
+        "-1"      | 100          | -1
+        null      | 100          | 100
+        ""        | 100          | 100
+        " "       | 100          | 100
+        " 123 "   | 100          | 123
     }
 
     def 'next group should have selections over defaults'() {


### PR DESCRIPTION
Implementation of convertToIntOrUseDefault could never accept 0 as a valid value since it would evaluate
to false and return the default value.

The use case this fix addresses is I want to create the next ASG in the cluster at size 0, then scale it
up with more controls to account for autoscaling scenarios (Instance termination disabled, etc)
