### PR TITLE
Log task finished listener processing errors.

### DIFF
--- a/grails-app/services/com/netflix/asgard/TaskService.groovy
+++ b/grails-app/services/com/netflix/asgard/TaskService.groovy
@@ -176,6 +176,8 @@ class TaskService {
             try {
                 taskFinishedListener.taskFinished(task)
             } catch (Exception e) {
+                String className = taskFinishedListener.getClass().simpleName
+                log.error "Task finished listener ${className} failed for task ${task.id} ${task.summary}", e
                 emailerService.sendExceptionEmail("Task finished plugin error: $e", e)
             }
         }


### PR DESCRIPTION
Some task finish events seem like they might not be getting into SNS. This logging might help find out why.
