### PR TITLE
Attempt to fix OneLogin problems.

### DIFF
--- a/grails-app/conf/com/netflix/asgard/AuthorizationFilters.groovy
+++ b/grails-app/conf/com/netflix/asgard/AuthorizationFilters.groovy
@@ -26,7 +26,7 @@ class AuthorizationFilters {
     def pluginService
 
     def filters = {
-        all(controller: '(cache|init|healthcheck|server|flag)', invert: true) {
+        all(controller: '(auth|cache|init|healthcheck|server|flag)', invert: true) {
             before = {
                 Collection<AuthorizationProvider> authorizationProviders = pluginService.authorizationProviders
                 if (authorizationProviders.any { !it.isAuthorized(request, controllerName, actionName) }) {


### PR DESCRIPTION
Some users are finding odd behavior from OneLogin and Asgard when authentication is required for browser GET requests.

Some users get an infinite redirect loop between Asgard and OneLogin, or at least a redirect that runs many times before finally stabilizing.

Some get OneLogin redirects to the Asgard home page, but logged out. This seems like it might be happening only when there are two Asgard instances receiving shared ELB traffic.

The errors are inconsistent but have happened to several users. I have a theory that some of the problems might stop if the auth controller is omitted from the list of controllers that require OneLogin authentication before being accessed.
