### PR TITLE
Enabled targeting multiple account for image replication

### DIFF
--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -46,7 +46,7 @@ typeMismatch.java.math.BigDecimal=Property {0} must be a valid number
 typeMismatch.java.math.BigInteger=Property {0} must be a valid number
 
 image.imageId.used=Image {3} cannot be deleted because it is in use in {4} environment by {5}
-image.imageId.prodInaccessible=Error: Image {3} cannot be deleted because AMI prod usage check failed on URL {4}
+image.imageId.remoteInaccessible=Error: Image {3} cannot be deleted because AMI remote usage check failed on URL {4}
 
 application.name.illegalChar=Name can only contain letters, numbers, underscores, and dots
 application.name.nonexistent=The specified application does not exist in the application registry

--- a/grails-app/services/com/netflix/asgard/ConfigService.groovy
+++ b/grails-app/services/com/netflix/asgard/ConfigService.groovy
@@ -630,6 +630,13 @@ class ConfigService {
     }
 
     /**
+     * @return the list of server root URLs for copying data such as image tags from a source account to target accounts
+     */
+    List<String> getPromotionTargetServerRootUrls() {
+        grailsApplication.config.promote?.targetServerRootUrls ?: []
+    }
+
+    /**
      * @return the base server URL for generating links to the current Asgard instance in outgoing emails
      */
     String getLinkCanonicalServerUrl() {

--- a/src/groovy/com/netflix/asgard/mock/Mocks.groovy
+++ b/src/groovy/com/netflix/asgard/mock/Mocks.groovy
@@ -138,7 +138,6 @@ class Mocks {
                                     awsAccounts: [TEST_AWS_ACCOUNT_ID, PROD_AWS_ACCOUNT_ID]
                             ],
                             promote: [
-                                    targetServer: 'http://prod',
                                     imageTags: true,
                                     canonicalServerForBakeEnvironment: 'http://test'
                             ],

--- a/test/unit/com/netflix/asgard/ImageServiceLastReferencedTaggingSpec.groovy
+++ b/test/unit/com/netflix/asgard/ImageServiceLastReferencedTaggingSpec.groovy
@@ -20,6 +20,7 @@ import com.amazonaws.services.ec2.model.Image
 import com.amazonaws.services.ec2.model.Instance
 import grails.converters.JSON
 
+@SuppressWarnings("GroovyAssignabilityCheck")
 class ImageServiceLastReferencedTaggingSpec extends ImageServiceSpec {
 
     def 'should tag if image is referenced in test instance'() {

--- a/test/unit/com/netflix/asgard/ImageServiceReplicateTagsSpec.groovy
+++ b/test/unit/com/netflix/asgard/ImageServiceReplicateTagsSpec.groovy
@@ -37,7 +37,7 @@ class ImageServiceReplicateTagsSpec extends ImageServiceSpec {
         imageService.runReplicateImageTags()
 
         then:
-        1 * restClientService.post({ it =~ /\/image\/addTags/ }, expectedPostData) >> 200
+        2 * restClientService.post({ it =~ /\/image\/addTags/ }, expectedPostData) >> 200
     }
 
     def 'should call separate updates for same key and different value'() {
@@ -54,8 +54,8 @@ class ImageServiceReplicateTagsSpec extends ImageServiceSpec {
         imageService.runReplicateImageTags()
 
         then:
-        1 * restClientService.post({ it =~ /\/image\/addTags/ }, expectedPostData) >> 200
-        1 * restClientService.post({ it =~ /\/image\/addTags/ }, expectedPostData2) >> 200
+        2 * restClientService.post({ it =~ /\/image\/addTags/ }, expectedPostData) >> 200
+        2 * restClientService.post({ it =~ /\/image\/addTags/ }, expectedPostData2) >> 200
     }
 
     def 'should delete tags if missing from production'() {
@@ -71,7 +71,7 @@ class ImageServiceReplicateTagsSpec extends ImageServiceSpec {
         imageService.runReplicateImageTags()
 
         then:
-        1 * restClientService.post({ it =~ /\/image\/removeTags/ }, expectedPostData) >> 200
+        2 * restClientService.post({ it =~ /\/image\/removeTags/ }, expectedPostData) >> 200
     }
 
     private setupReplicateTestAndProdImages(List<Image> testImages, List<Image> prodImages) {
@@ -94,8 +94,8 @@ class ImageServiceReplicateTagsSpec extends ImageServiceSpec {
         }
         GPathResult prodImagesXml = XML.parse(sw.toString()) as GPathResult
         awsEc2Service.getAccountImages(UserContext.auto()) >> testImages
-        1 * restClientService.getAsXml({ it =~ /\/us-east-1\/image\/list\.xml/ }) >> prodImagesXml
-
+        restClientService.getAsXml({ it =~ /\/us-east-1\/image\/list\.xml/ }) >> prodImagesXml
+        configService.getPromotionTargetServerRootUrls() >> ['http://staging', 'http://prod']
         restClientService.getAsText(_, _) >> InetAddress.getLocalHost().getHostName()
         restClientService.getResponseCode(_) >> 200
         awsEc2Service.getAccountImages(_) >> []

--- a/test/unit/com/netflix/asgard/ImageServiceSpec.groovy
+++ b/test/unit/com/netflix/asgard/ImageServiceSpec.groovy
@@ -48,6 +48,7 @@ abstract class ImageServiceSpec extends Specification {
     void setupLastReferencedDefaults() {
         awsEc2Service.getInstances(_) >> []
         awsAutoScalingService.getLaunchConfigurations(_) >> []
+        configService.getPromotionTargetServerRootUrls() >> ['http://prod']
         restClientService.getAsJson({ it =~ /\/image\/used.json/ }) >> JSON.parse('[]')
     }
 


### PR DESCRIPTION
The old code assumed that there could only be a single target account for image replication.
