### PR TITLE
a running deployment should be available from the cluster page

### DIFF
--- a/app/views/deployment/detail.html
+++ b/app/views/deployment/detail.html
@@ -23,10 +23,6 @@
             <div class="col-sm-8"><span id="taskStatus">{{deployment.status}}</span></div>
         </div>
         <div class="row">
-            <div class="col-sm-4">Start Time:</div>
-            <div class="col-sm-8">{{deployment.startTime | date: 'yyyy-MM-dd HH:mm:ss Z'}}</div>
-        </div>
-        <div class="row">
             <div class="col-sm-4">Duration:</div>
             <div class="col-sm-8"><span id="taskDurationString">{{deployment.durationString}}</span></div>
         </div>

--- a/grails-app/controllers/com/netflix/asgard/ClusterController.groovy
+++ b/grails-app/controllers/com/netflix/asgard/ClusterController.groovy
@@ -52,6 +52,7 @@ class ClusterController {
     def awsEc2Service
     def awsLoadBalancerService
     def configService
+    def deploymentService
     def mergedInstanceService
     def pushService
     def spotInstanceRequestService
@@ -157,7 +158,8 @@ ${lastGroup.loadBalancerNames}"""
                             loadBalancersGroupedByVpcId: loadBalancers.groupBy { it.VPCId },
                             selectedLoadBalancers: selectedLoadBalancers,
                             spotUrl: configService.spotUrl,
-                            pricing: params.pricing ?: attributes.pricing
+                            pricing: params.pricing ?: attributes.pricing,
+                            deployment: deploymentService.getRunningDeploymentForCluster(cluster.name)
                     ])
                     attributes
                 }

--- a/grails-app/services/com/netflix/asgard/TaskService.groovy
+++ b/grails-app/services/com/netflix/asgard/TaskService.groovy
@@ -209,7 +209,7 @@ class TaskService {
      * @return a single concatenated list of all locally cached running tasks (without tasks on other Asgard servers)
      */
     List<Task> getAllRunningInCache() {
-        localRunningInMemory + allRunningInSwf
+        localRunningInMemory
     }
 
     /**

--- a/grails-app/views/cluster/show.gsp
+++ b/grails-app/views/cluster/show.gsp
@@ -29,15 +29,24 @@
       <g:if test="${flash.message}">
         <div class="message">${flash.message}</div>
       </g:if>
-      <g:if test="${!runningTasks && !requireLoginForEdit}">
-        <div class="buttons">
-          <g:link class="deploy" controller="ng" action=" " fragment="deployment/new/${params.id}">Prepare Automated Deployment</g:link>
-        </div>
+      <g:if test="${deployment}">
+        <div class="warning">Cancel the automated deployment currently running before manually editing this cluster.</div>
+        <h3>Running deployment:</h3>
+        <g:link class="deployment" controller="ng" action=" " fragment="deployment/detail/${deployment.id}">${deployment.description}</g:link>
+        <p></p>
       </g:if>
-      <p>
-        Recommended next step: <br/>
-        <em>${recommendedNextStep}</em>
-      </p>
+      <g:else>
+        <g:if test="${!runningTasks && !requireLoginForEdit}">
+          <div class="buttons">
+            <g:link class="deploy" controller="ng" action=" " fragment="deployment/new/${params.id}">Prepare Automated Deployment</g:link>
+          </div>
+        </g:if>
+        <p>
+          Recommended next step: <br/>
+          <em>${recommendedNextStep}</em>
+        </p>
+      </g:else>
+    </div>
       <g:if test="${runningTasks}">
         <h3>Running tasks:</h3>
         <ul class="tasks">

--- a/src/groovy/com/netflix/asgard/deployment/DeploymentActivities.groovy
+++ b/src/groovy/com/netflix/asgard/deployment/DeploymentActivities.groovy
@@ -146,7 +146,8 @@ interface DeploymentActivities {
      */
     @ActivityRegistrationOptions(defaultTaskScheduleToStartTimeoutSeconds = -1L,
             defaultTaskStartToCloseTimeoutSeconds = 86400L)
-    Boolean askIfDeploymentShouldProceed(String notificationDestination, String asgName, String operationDescription)
+    Boolean askIfDeploymentShouldProceed(UserContext userContext, String notificationDestination, String asgName,
+            String operationDescription)
 
     /**
      * Sends a notification about the status of the deployment.

--- a/src/groovy/com/netflix/asgard/deployment/DeploymentActivitiesImpl.groovy
+++ b/src/groovy/com/netflix/asgard/deployment/DeploymentActivitiesImpl.groovy
@@ -199,13 +199,15 @@ class DeploymentActivitiesImpl implements DeploymentActivities {
 
     @ManualActivityCompletion
     @Override
-    Boolean askIfDeploymentShouldProceed(String notificationDestination, String asgName, String operationDescription) {
+    Boolean askIfDeploymentShouldProceed(UserContext userContext, String notificationDestination, String asgName,
+            String operationDescription) {
         WorkflowExecutionBeanOptions workflowExecutionBeanOptions = awsSimpleWorkflowService.
                 getWorkflowExecutionInfoByWorkflowExecution(activity.workflowExecution)
         SwfWorkflowTags tags = workflowExecutionBeanOptions.tags
         deploymentService.setManualTokenForDeployment(tags.id, activity.taskToken)
-        String link = grailsLinkGenerator.link(base: configService.linkCanonicalServerUrl, controller: 'ng',
-                action: ' ', fragment: "deployment/detail/${tags.id}")
+        String clusterName = Relationships.clusterFromGroupName(asgName)
+        String link = grailsLinkGenerator.link(base: configService.linkCanonicalServerUrl, controller: 'cluster',
+                action: 'show', params: [id: clusterName, region: userContext.region.code])
         String message = """
         Auto Scaling Group '${asgName}' is being deployed.
         ${operationDescription}

--- a/src/groovy/com/netflix/asgard/deployment/DeploymentWorkflowImpl.groovy
+++ b/src/groovy/com/netflix/asgard/deployment/DeploymentWorkflowImpl.groovy
@@ -252,8 +252,8 @@ initially with 0 instances."
         String judgmentMessage = "ASG will now be evaluated for up to ${unit(judgmentPeriodMinutes, 'minute')}" +
                 " during the judgment period."
         status judgmentMessage
-        Promise<Boolean> proceed = promiseFor(activities.askIfDeploymentShouldProceed(notificationDestination,
-                    asgName, judgmentMessage))
+        Promise<Boolean> proceed = promiseFor(activities.askIfDeploymentShouldProceed(userContext,
+                notificationDestination, asgName, judgmentMessage))
         DoTry<Void> sendNotificationAtJudgmentTimeout = doTry {
             Promise<Void> judgmentTimeout = timer(minutesToSeconds(judgmentPeriodMinutes), 'judgmentTimeout')
             waitFor(judgmentTimeout) {

--- a/test/unit/com/netflix/asgard/ClusterControllerSpec.groovy
+++ b/test/unit/com/netflix/asgard/ClusterControllerSpec.groovy
@@ -76,6 +76,7 @@ class ClusterControllerSpec extends Specification {
             awsLoadBalancerService.getLoadBalancers(_) >> []
             configService = Mock(ConfigService)
             configService.clusterMaxGroups >> 3
+            deploymentService = Mock(DeploymentService)
         }
     }
 

--- a/test/unit/com/netflix/asgard/deployment/DeploymentActivitiesSpec.groovy
+++ b/test/unit/com/netflix/asgard/deployment/DeploymentActivitiesSpec.groovy
@@ -274,8 +274,8 @@ class DeploymentActivitiesSpec extends Specification {
 
     def 'should ask if deployment should proceed'() {
         when:
-        deploymentActivities.askIfDeploymentShouldProceed('hrearden@reardenmetal.com', 'rearden_metal_pourer-v001',
-                'It has finished pouring.')
+        deploymentActivities.askIfDeploymentShouldProceed(UserContext.auto(), 'hrearden@reardenmetal.com',
+                'rearden_metal_pourer-v001', 'It has finished pouring.')
 
         then:
         with(mockActivityOperations) {

--- a/test/unit/com/netflix/asgard/deployment/DeploymentWorkflowSpec.groovy
+++ b/test/unit/com/netflix/asgard/deployment/DeploymentWorkflowSpec.groovy
@@ -158,7 +158,7 @@ class DeploymentWorkflowSpec extends Specification {
         then: 1 * mockActivities.reasonAsgIsNotOperational(userContext, 'the_seaward-v003', 1) >> ''
         then: 1 * mockActivities.startAsgAnalysis('the_seaward', 'gob@bluth.com') >> new ScheduledAsgAnalysis(
                 "ASG analysis for 'the_seaward' cluster.", new DateTime())
-        then: 1 * mockActivities.askIfDeploymentShouldProceed('gob@bluth.com', 'the_seaward-v003',
+        then: 1 * mockActivities.askIfDeploymentShouldProceed(_, 'gob@bluth.com', 'the_seaward-v003',
                 "ASG will now be evaluated for up to 60 minutes during the judgment period.") >> false
         then: 1 * mockActivities.sendNotification(_, 'gob@bluth.com', 'the_seaward',
                 "Judgment period for ASG 'the_seaward-v003' has ended.",
@@ -386,7 +386,7 @@ class DeploymentWorkflowSpec extends Specification {
         then: 1 * mockActivities.reasonAsgIsNotOperational(userContext, 'the_seaward-v003', 1) >> ''
         then: 1 * mockActivities.startAsgAnalysis('the_seaward', 'gob@bluth.com') >> new ScheduledAsgAnalysis(
                 "ASG analysis for 'the_seaward' cluster.", new DateTime())
-        then: 1 * mockActivities.askIfDeploymentShouldProceed('gob@bluth.com', 'the_seaward-v003',
+        then: 1 * mockActivities.askIfDeploymentShouldProceed(_, 'gob@bluth.com', 'the_seaward-v003',
                 "ASG will now be evaluated for up to 60 minutes during the judgment period.") >> false
         then: 1 * mockActivities.enableAsg(userContext, 'the_seaward-v002') >> true
         then: 1 * mockActivities.disableAsg(userContext, 'the_seaward-v003') >> true
@@ -425,7 +425,7 @@ class DeploymentWorkflowSpec extends Specification {
         then: 1 * mockActivities.reasonAsgIsNotOperational(userContext, 'the_seaward-v003', 1) >> ''
         then: 1 * mockActivities.startAsgAnalysis('the_seaward', 'gob@bluth.com') >> new ScheduledAsgAnalysis(
                 "ASG analysis for 'the_seaward' cluster.", new DateTime())
-        then: 1 * mockActivities.askIfDeploymentShouldProceed('gob@bluth.com', 'the_seaward-v003',
+        then: 1 * mockActivities.askIfDeploymentShouldProceed(_, 'gob@bluth.com', 'the_seaward-v003',
                 "ASG will now be evaluated for up to 60 minutes during the judgment period.") >> true
         then: 1 * mockActivities.stopAsgAnalysis("ASG analysis for 'the_seaward' cluster.")
         then: 1 * mockActivities.resizeAsg(userContext, 'the_seaward-v003', 1, 3, 4)
@@ -465,7 +465,7 @@ class DeploymentWorkflowSpec extends Specification {
         then: 1 * mockActivities.reasonAsgIsNotOperational(userContext, 'the_seaward-v003', 3) >> ''
         then: 1 * mockActivities.startAsgAnalysis('the_seaward', 'gob@bluth.com') >> new ScheduledAsgAnalysis(
                 "ASG analysis for 'the_seaward' cluster.", new DateTime())
-        then: 1 * mockActivities.askIfDeploymentShouldProceed('gob@bluth.com', 'the_seaward-v003',
+        then: 1 * mockActivities.askIfDeploymentShouldProceed(_, 'gob@bluth.com', 'the_seaward-v003',
                 "ASG will now be evaluated for up to 120 minutes during the judgment period.") >> false
         then: 1 * mockActivities.enableAsg(userContext, 'the_seaward-v002') >> true
         then: 1 * mockActivities.disableAsg(userContext, 'the_seaward-v003') >> true
@@ -512,7 +512,7 @@ class DeploymentWorkflowSpec extends Specification {
         then: 1 * mockActivities.reasonAsgIsNotOperational(userContext, 'the_seaward-v003', 3) >> ''
         then: 1 * mockActivities.startAsgAnalysis('the_seaward', 'gob@bluth.com') >> new ScheduledAsgAnalysis(
                 "ASG analysis for 'the_seaward' cluster.", new DateTime())
-        then: 1 * mockActivities.askIfDeploymentShouldProceed('gob@bluth.com', 'the_seaward-v003',
+        then: 1 * mockActivities.askIfDeploymentShouldProceed(_, 'gob@bluth.com', 'the_seaward-v003',
                 "ASG will now be evaluated for up to 120 minutes during the judgment period.") >> true
         then: 1 * mockActivities.stopAsgAnalysis("ASG analysis for 'the_seaward' cluster.")
         then: 1 * mockActivities.disableAsg(userContext, 'the_seaward-v002')
@@ -591,7 +591,7 @@ class DeploymentWorkflowSpec extends Specification {
         then: 1 * mockActivities.disableAsg(userContext, 'the_seaward-v002')
         then: 1 * mockActivities.startAsgAnalysis('the_seaward', 'gob@bluth.com') >> new ScheduledAsgAnalysis(
                 "ASG analysis for 'the_seaward' cluster.", new DateTime())
-        then: 1 * mockActivities.askIfDeploymentShouldProceed('gob@bluth.com', 'the_seaward-v003',
+        then: 1 * mockActivities.askIfDeploymentShouldProceed(_, 'gob@bluth.com', 'the_seaward-v003',
                 "ASG will now be evaluated for up to 240 minutes during the judgment period.") >> false
         then: 1 * mockActivities.enableAsg(userContext, 'the_seaward-v002') >> true
         then: 1 * mockActivities.disableAsg(userContext, 'the_seaward-v003') >> true

--- a/web-app/css/main.css
+++ b/web-app/css/main.css
@@ -399,6 +399,7 @@ a.dbSecurity          { padding:  2px 2px  2px 26px; background: url(../images/t
 a.dbSnapshot          { padding:  2px 2px  2px 26px; background: url(../images/tango/16/devices/database-snapshot.png)           transparent no-repeat 5px 1px; display: inline-block; line-height: 16px; min-height: 16px; }
 a.cloudready          { padding:  2px 2px  2px 26px; background: url(../images/tango/16/emotes/face-monkey.png)                  transparent no-repeat 5px 1px; display: inline-block; line-height: 16px; min-height: 16px; }
 a.task                { padding:  2px 2px  2px 24px; background: url(../images/tango/16/actions/edit-paste.png)                  transparent no-repeat 3px 1px; display: inline-block; line-height: 17px; min-height: 17px; }
+a.deployment          { padding:  2px 2px  2px 24px; background: url(../images/tango/16/tools/deploy.png)                        transparent no-repeat 5px 1px; display: inline-block; line-height: 16px; min-height: 16px; }
 a.builds              { padding:  2px 2px  2px 22px; background: url(../images/builds.png)                                       transparent no-repeat 5px 1px; display: inline-block; line-height: 16px; min-height: 16px; }
 a.mail                { padding:  2px 2px  2px 22px; background: url(../images/tango/16/actions/mail-message-new.png)            transparent no-repeat 0   1px; display: inline-block; line-height: 16px; min-height: 16px; }
 a.jira                { padding:  2px 2px  2px 22px; background: url(../images/jira.png)                                         transparent no-repeat 0   1px; display: inline-block; line-height: 16px; min-height: 16px; }
@@ -458,7 +459,7 @@ label.choice        { padding-right: 15px; }
 table.securityGroups { width: auto; }
 td.checkbox          { text-align: center; }
 
-.deployment { margin-bottom: 800px; }
+div.deployment { margin-bottom: 800px; }
 .deployment input[type="radio"] { margin: 3px !important; }
 .deployment div label { font-weight: normal }
 .deployment .well { margin: 5px; }


### PR DESCRIPTION
we also show a warning and use a link to the cluster in notifications because the fragment part of the deployment URL was getting lost with redirects
