### PR TITLE
Display HTML5 notifications when a task is no longer running

### DIFF
--- a/web-app/js/custom.js
+++ b/web-app/js/custom.js
@@ -968,6 +968,11 @@ jQuery(document).ready(function() {
                     if (taskData.status !== 'running') {
                         poller.stop = true;
                         jCancellationForm.slideUp();
+                        if('Notification' in window) {
+                            var notification = new Notification("Job's Done", {
+                                'body': taskData.status
+                            });
+                        }
                     }
                 },
                 contentType: 'application/json'
@@ -1720,5 +1725,16 @@ jQuery(document).ready(function() {
         });
     };
     setUpTableSortability();
+
+    var setUpNotifications = function() {
+        if('Notification' in window && Notification.permission !== 'granted') {
+            Notification.requestPermission(function(permission) {
+                if(Notification.permission !== permission) {
+                    Notification.permission = permission;
+                }
+            });
+        }
+    };
+    setUpNotifications();
 
 });


### PR DESCRIPTION
Sometimes bringing up a set of machines can take a while, and the user
would like to know when the process is complete.  Currently, the user
has to check back with Asgard every so often.  This commit introduces
the use of HTML5 notifications (which are not used if unsupported by
the user's browser) to inform the user when the task has completed or
failed.
