### PR TITLE
Placement tenancy

### DIFF
--- a/app/views/deployment/new.html
+++ b/app/views/deployment/new.html
@@ -159,6 +159,17 @@
               <label for="ebsOptimizedFalse" class="choice">No</label>
           </div>
         </div>
+        <div class="row" collapse="hideAdvancedItems">
+          <div class="col-md-3">
+            <label>Placement Tenancy:</label>
+          </div>
+          <div class="col-md-9">
+            <input type="radio" ng-model="lcOptions.placementTenancy" ng-value="default" id="placementTenancyDefault">
+            <label for="placementTenancyDefault" class="choice">Multi-tenant</label>
+            <input type="radio" ng-model="lcOptions.placementTenancy" ng-value="dedicated" id="placementTenancyDedicated">
+            <label for="placementTenancyDedicated" class="choice">Single-tenant</label>
+          </div>
+        </div>
       </div>
 
       <div class="autoScalingGroupOptions container" collapse="hideAdvancedItems">

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -93,7 +93,7 @@ grails.project.dependency.resolution = {
 
         compile(
                 // Amazon Web Services programmatic interface. Transitive dependency of glisten, but also used directly.
-                'com.amazonaws:aws-java-sdk:1.7.5',
+                'com.amazonaws:aws-java-sdk:1.9.34',
 
                 // Enables publication of a health check URL for deploying Asgard, and an on/off switch for activities.
                 // Transitive dependencies include:

--- a/grails-app/controllers/com/netflix/asgard/AutoScalingController.groovy
+++ b/grails-app/controllers/com/netflix/asgard/AutoScalingController.groovy
@@ -334,11 +334,13 @@ class AutoScalingController {
             boolean ebsOptimized = params.ebsOptimized?.toBoolean()
             boolean enableMonitoring = params.enableInstanceMonitoring ? params.enableInstanceMonitoring.toBoolean() :
                     configService.enableInstanceMonitoring
+            String placementTenancy = params.placementTenancy ?: "default"
             LaunchConfiguration launchConfigTemplate = new LaunchConfiguration().withImageId(imageId).
                     withKernelId(kernelId).withInstanceType(instType).withKeyName(keyName).withRamdiskId(ramdiskId).
                     withSecurityGroups(securityGroups).withIamInstanceProfile(iamInstanceProfile).
                     withEbsOptimized(ebsOptimized).withInstanceMonitoring(new InstanceMonitoring()
-                        .withEnabled(enableMonitoring))
+                        .withEnabled(enableMonitoring)).
+                    withPlacementTenancy(placementTenancy)
             if (params.pricing == InstancePriceType.SPOT.name()) {
                 launchConfigTemplate.spotPrice = spotInstanceRequestService.recommendSpotPrice(userContext, instType)
             }

--- a/grails-app/controllers/com/netflix/asgard/ClusterController.groovy
+++ b/grails-app/controllers/com/netflix/asgard/ClusterController.groovy
@@ -251,6 +251,7 @@ ${loadBalancerNames}"""
 Group: ${lastGroup.loadBalancerNames}"""
             boolean ebsOptimized = params.containsKey('ebsOptimized') ? params.ebsOptimized?.toBoolean() :
                 lastLaunchConfig.ebsOptimized
+            String placementTenancy = params.placementTenancy ?: lastLaunchConfig.placementTenancy
             if (params.noOptionalDefaults != 'true') {
                 securityGroups = securityGroups ?: lastLaunchConfig.securityGroups
                 termPolicies = termPolicies ?: lastGroup.terminationPolicies
@@ -291,7 +292,8 @@ Group: ${loadBalancerNames}"""
                     scheduledActions: newScheduledActions,
                     vpcZoneIdentifier: vpcZoneIdentifier,
                     spotPrice: spotPrice,
-                    ebsOptimized: ebsOptimized
+                    ebsOptimized: ebsOptimized,
+                    placementTenancy: placementTenancy
             )
             def operation = pushService.startGroupCreate(options)
             flash.message = "${operation.task.name} has been started."

--- a/grails-app/controllers/com/netflix/asgard/ImageController.groovy
+++ b/grails-app/controllers/com/netflix/asgard/ImageController.groovy
@@ -428,7 +428,8 @@ class ImageDeleteCommand {
     static constraints = {
         id(nullable: false, blank: false, size: 12..12, validator: { String value, ImageDeleteCommand command ->
             UserContext userContext = UserContext.of(Requests.request)
-            List<String> promotionTargetServerRootUrls = command.grailsApplication.config.promote?.targetServerRootUrls ?: []
+            List<String> promotionTargetServerRootUrls =
+                    command.grailsApplication.config.promote?.targetServerRootUrls ?: []
             String promotionTargetServer = command.grailsApplication.config.promote.targetServer
             String env = command.grailsApplication.config.cloud.accountName
 

--- a/grails-app/controllers/com/netflix/asgard/ImageController.groovy
+++ b/grails-app/controllers/com/netflix/asgard/ImageController.groovy
@@ -422,14 +422,13 @@ class ImageDeleteCommand {
     AwsAutoScalingService awsAutoScalingService
     AwsEc2Service awsEc2Service
     RestClientService restClientService
-    ConfigService configService
     def grailsApplication
 
     @SuppressWarnings("GroovyAssignabilityCheck")
     static constraints = {
         id(nullable: false, blank: false, size: 12..12, validator: { String value, ImageDeleteCommand command ->
             UserContext userContext = UserContext.of(Requests.request)
-            List<String> promotionTargetServerRootUrls = configService.promotionTargetServerRootUrls
+            List<String> promotionTargetServerRootUrls = command.grailsApplication.config.promote?.targetServerRootUrls ?: []
             String promotionTargetServer = command.grailsApplication.config.promote.targetServer
             String env = command.grailsApplication.config.cloud.accountName
 

--- a/grails-app/views/launchConfiguration/_launchConfigOptions.gsp
+++ b/grails-app/views/launchConfiguration/_launchConfigOptions.gsp
@@ -104,7 +104,7 @@
       <label for="ebsOptimized">EBS Optimized?</label>
     </td>
     <td>
-      <input id="ebsOptimized" type="checkbox" name="ebsOptimized" /> (may incur additional costs)
+      <input id="ebsOptimized" type="checkbox" value="true" name="ebsOptimized" /> (may incur additional costs)
     </td>
   </tr>
   <tr class="prop advanced">

--- a/grails-app/views/launchConfiguration/_launchConfigOptions.gsp
+++ b/grails-app/views/launchConfiguration/_launchConfigOptions.gsp
@@ -99,4 +99,23 @@
       <input type="text" id="iamInstanceProfile" name="iamInstanceProfile" value="${params.iamInstanceProfile ?: iamInstanceProfile}"/>
     </td>
   </tr>
+  <tr class="prop advanced">
+    <td class="name">
+      <label for="ebsOptimized">EBS Optimized?</label>
+    </td>
+    <td>
+      <input id="ebsOptimized" type="checkbox" name="ebsOptimized" /> (may incur additional costs)
+    </td>
+  </tr>
+  <tr class="prop advanced">
+    <td class="name">
+      Placement Tenancy
+    </td>
+    <td>
+      <input type="radio" name="placementTenancy" value="default" id="placementTenancyDefault" ${params.placementTenancy != 'dedicated' ? 'checked="checked"' : ''}>
+      <label for="placementTenancyDefault" class="choice">Multi-tenant (default)</label>
+      <input type="radio" name="placementTenancy" value="dedicated" id="placementTenancyDedicated" ${params.placementTenancy == 'dedicated' ? 'checked="checked"' : ''}>
+      <label for="placementTenancyDedicated" class="choice">Single-tenant</label>
+    </td>
+  </tr>
 </tbody>

--- a/src/groovy/com/netflix/asgard/cred/AsgardAWSCredentialsProviderChain.groovy
+++ b/src/groovy/com/netflix/asgard/cred/AsgardAWSCredentialsProviderChain.groovy
@@ -1,4 +1,4 @@
-/*
+    /*
  * Copyright 2014 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -52,20 +52,34 @@ import com.netflix.asgard.RestClientService
  */
 class AsgardAWSCredentialsProviderChain extends AWSCredentialsProviderChain {
     public AsgardAWSCredentialsProviderChain(ConfigService configService, RestClientService restClientService) {
-        super(
-                // Varargs in Java constructor work against elegance of super call in Groovy subclass
-                [
-                        new EnvironmentVariableCredentialsProvider(),
-                        new SystemPropertiesCredentialsProvider(),
-                        new ConfigCredentialsProvider(configService),
-                        new LocalFilesCredentialsProvider(configService),
-                        new SshCredentialsProvider(configService),
-                        new KeyManagementServiceAssumeRoleCredentialsProvider(configService, restClientService),
-                        new KeyManagementServiceCredentialsProvider(configService, restClientService),
-                        new STSAssumeRoleSessionCredentialsProvider(configService.assumeRoleArn,
-                                configService.assumeRoleSessionName),
-                        new InstanceProfileCredentialsProvider()
-                ] as AWSCredentialsProvider[]
-        )
+        super(makeChain(configService, restClientService))
+    }
+
+    public static AWSCredentialsProvider[] makeChain(ConfigService configService, RestClientService restClientService) {
+        if (configService.assumeRoleArn != null && configService.assumeRoleSessionName != null) {
+            return [
+                    new EnvironmentVariableCredentialsProvider(),
+                    new SystemPropertiesCredentialsProvider(),
+                    new ConfigCredentialsProvider(configService),
+                    new LocalFilesCredentialsProvider(configService),
+                    new SshCredentialsProvider(configService),
+                    new KeyManagementServiceAssumeRoleCredentialsProvider(configService, restClientService),
+                    new KeyManagementServiceCredentialsProvider(configService, restClientService),
+                    new STSAssumeRoleSessionCredentialsProvider(configService.assumeRoleArn as String,
+                            configService.assumeRoleSessionName as String),
+                    new InstanceProfileCredentialsProvider()
+            ] as AWSCredentialsProvider[]
+        } else {
+            return [
+                    new EnvironmentVariableCredentialsProvider(),
+                    new SystemPropertiesCredentialsProvider(),
+                    new ConfigCredentialsProvider(configService),
+                    new LocalFilesCredentialsProvider(configService),
+                    new SshCredentialsProvider(configService),
+                    new KeyManagementServiceAssumeRoleCredentialsProvider(configService, restClientService),
+                    new KeyManagementServiceCredentialsProvider(configService, restClientService),
+                    new InstanceProfileCredentialsProvider()
+            ] as AWSCredentialsProvider[]
+        }
     }
 }

--- a/src/groovy/com/netflix/asgard/model/LaunchConfigurationBeanOptions.groovy
+++ b/src/groovy/com/netflix/asgard/model/LaunchConfigurationBeanOptions.groovy
@@ -72,6 +72,9 @@ import groovy.transform.Canonical
     /** @see LaunchConfiguration#associatePublicIpAddress */
     Boolean associatePublicIpAddress
 
+    /** @see LaunchConfiguration#getPlacementTenancy */
+    String placementTenancy
+
     void setSecurityGroups(Collection<String> securityGroups) {
         this.securityGroups = copyNonNullToSet(securityGroups)
     }
@@ -110,7 +113,8 @@ import groovy.transform.Canonical
                 instancePriceType: source.instancePriceType,
                 iamInstanceProfile: source.iamInstanceProfile,
                 ebsOptimized: source.ebsOptimized,
-                associatePublicIpAddress: source.associatePublicIpAddress
+                associatePublicIpAddress: source.associatePublicIpAddress,
+                placementTenancy: source.placementTenancy
         )
     }
 
@@ -136,7 +140,8 @@ import groovy.transform.Canonical
                     instancePriceType: spotPrice ? InstancePriceType.SPOT : InstancePriceType.ON_DEMAND,
                     iamInstanceProfile: iamInstanceProfile,
                     ebsOptimized: ebsOptimized,
-                    associatePublicIpAddress: associatePublicIpAddress
+                    associatePublicIpAddress: associatePublicIpAddress,
+                    placementTenancy: placementTenancy
             )
         }
     }
@@ -168,7 +173,8 @@ import groovy.transform.Canonical
                 spotPrice: spotPrice,
                 iamInstanceProfile: iamInstanceProfile,
                 ebsOptimized: ebsOptimized,
-                associatePublicIpAddress: associatePublicIpAddress
+                associatePublicIpAddress: associatePublicIpAddress,
+                placementTenancy: placementTenancy
         )
     }
 

--- a/src/groovy/com/netflix/asgard/push/GroupCreateOperation.groovy
+++ b/src/groovy/com/netflix/asgard/push/GroupCreateOperation.groovy
@@ -81,7 +81,8 @@ class GroupCreateOperation extends AbstractPushOperation {
                     withKeyName(options.keyName).withRamdiskId(options.ramdiskId).
                     withSecurityGroups(options.common.securityGroups).
                     withIamInstanceProfile(options.iamInstanceProfile).
-                    withSpotPrice(options.spotPrice).withEbsOptimized(options.ebsOptimized)
+                    withSpotPrice(options.spotPrice).withEbsOptimized(options.ebsOptimized).
+                    withPlacementTenancy(options.placementTenancy)
 
             final Collection<AutoScalingProcessType> suspendedProcesses = Sets.newHashSet()
             if (options.zoneRebalancingSuspended) {

--- a/src/groovy/com/netflix/asgard/push/GroupCreateOptions.groovy
+++ b/src/groovy/com/netflix/asgard/push/GroupCreateOptions.groovy
@@ -37,6 +37,7 @@ import groovy.transform.Immutable
     Collection<ScheduledUpdateGroupAction> scheduledActions
     String spotPrice
     boolean ebsOptimized
+    String placementTenancy
 
     /** The number of instances to create at a time while inflating the auto scaling group. */
     Integer batchSize

--- a/src/groovy/com/netflix/asgard/push/RollingPushOperation.groovy
+++ b/src/groovy/com/netflix/asgard/push/RollingPushOperation.groovy
@@ -117,7 +117,8 @@ class RollingPushOperation extends AbstractPushOperation {
                 securityGroups: securityGroups, instanceType: options.instanceType,
                 kernelId: oldLaunch.kernelId, ramdiskId: oldLaunch.ramdiskId, iamInstanceProfile: iamInstanceProfile,
                 ebsOptimized: oldLaunch.ebsOptimized,
-                instancePriceType: options.spotPrice ? InstancePriceType.SPOT : InstancePriceType.ON_DEMAND
+                instancePriceType: options.spotPrice ? InstancePriceType.SPOT : InstancePriceType.ON_DEMAND,
+                placementTenancy: oldLaunch.placementTenancy
         )
         UserContext userContext = options.common.userContext
         Subnets subnets = awsEc2Service.getSubnets(userContext)

--- a/test/unit/com/netflix/asgard/AutoScalingControllerSpec.groovy
+++ b/test/unit/com/netflix/asgard/AutoScalingControllerSpec.groovy
@@ -388,8 +388,8 @@ class AutoScalingControllerSpec extends Specification {
         'false'             | false
     }
 
-    @Unroll("save should create placement tenancy #placementTenancyValue " +
-            " launch config for param #placementTenancyParam")
+    @Unroll("save should create placement tenancy #placementTenancyValue \
+             launch config for param #placementTenancyParam")
     def 'save should create config with placement tenancy'() {
         controller.configService = Mock(ConfigService)
         controller.awsAutoScalingService = Mock(AwsAutoScalingService)

--- a/test/unit/com/netflix/asgard/AutoScalingControllerSpec.groovy
+++ b/test/unit/com/netflix/asgard/AutoScalingControllerSpec.groovy
@@ -387,8 +387,9 @@ class AutoScalingControllerSpec extends Specification {
         'true'              | true
         'false'             | false
     }
-    
-    @Unroll("save should create placement tenancy #placementTenancyValue launch config for param #placementTenancyParam")
+
+    @Unroll("save should create placement tenancy #placementTenancyValue " +
+            " launch config for param #placementTenancyParam")
     def 'save should create config with placement tenancy'() {
         controller.configService = Mock(ConfigService)
         controller.awsAutoScalingService = Mock(AwsAutoScalingService)

--- a/test/unit/com/netflix/asgard/DeploymentControllerSpec.groovy
+++ b/test/unit/com/netflix/asgard/DeploymentControllerSpec.groovy
@@ -321,7 +321,8 @@ class DeploymentControllerSpec extends Specification {
                 instanceMonitoring: new InstanceMonitoring(enabled: false),
                 iamInstanceProfile: "BaseIAMRole",
                 ebsOptimized: false,
-                associatePublicIpAddress: false
+                associatePublicIpAddress: false,
+                placementTenancy: "default"
         )
         Subnets subnets = new Subnets([
                 new SubnetData("1", "", "vpc1", "", 1, "us-east-1", "internal", SubnetTarget.EC2)
@@ -347,7 +348,8 @@ class DeploymentControllerSpec extends Specification {
                         instancePriceType: "ON_DEMAND",
                         iamInstanceProfile: "BaseIAMRole",
                         ebsOptimized: false,
-                        associatePublicIpAddress: false
+                        associatePublicIpAddress: false,
+                        placementTenancy: "default"
                 ],
                 asgOptions: [
                         autoScalingGroupName: null,
@@ -414,7 +416,8 @@ class DeploymentControllerSpec extends Specification {
                 instanceMonitoring: null,
                 iamInstanceProfile: "BaseIAMRole",
                 ebsOptimized: false,
-                associatePublicIpAddress: false
+                associatePublicIpAddress: false,
+                placementTenancy: "default"
         )
         Subnets subnets = new Subnets([
                 new SubnetData("1", "", "vpc1", "", 1, "us-east-1", "internal", SubnetTarget.EC2)
@@ -450,7 +453,8 @@ class DeploymentControllerSpec extends Specification {
                         instancePriceType: "ON_DEMAND",
                         iamInstanceProfile: "BaseIAMRole",
                         ebsOptimized: false,
-                        associatePublicIpAddress: false
+                        associatePublicIpAddress: false,
+                        placementTenancy: "default"
                 ],
                 asgOptions: [
                         autoScalingGroupName: null,

--- a/test/unit/com/netflix/asgard/EmailerServiceUnitSpec.groovy
+++ b/test/unit/com/netflix/asgard/EmailerServiceUnitSpec.groovy
@@ -182,9 +182,8 @@ java.io.IOException: Unable to reach Internet due to comet
         Exception grailsException = new GrailsRuntimeException('Something went wrong', deleteConflictException)
         String expectedSubject = "Trouble: HalService HalKnowsBest DeleteConflictException"
         String expectedBodyStart = """You tried to terminate HAL, yet he lives
-com.amazonaws.services.identitymanagement.model.DeleteConflictException: Status Code: 403, AWS Service: HalService, \
-AWS Request ID: deadbeef, AWS Error Code: HalKnowsBest, \
-AWS Error Message: I'm sorry, Dave. I'm afraid I can't do that.
+com.amazonaws.services.identitymanagement.model.DeleteConflictException: I'm sorry, Dave. I'm afraid I can't do that. \
+(Service: HalService; Status Code: 403; Error Code: HalKnowsBest; Request ID: deadbeef)
 \tat"""
 
         when:

--- a/test/unit/com/netflix/asgard/HostedZoneControllerSpec.groovy
+++ b/test/unit/com/netflix/asgard/HostedZoneControllerSpec.groovy
@@ -111,8 +111,8 @@ class HostedZoneControllerSpec extends Specification {
             e.statusCode = 503
             throw e
         }
-        controller.flash.message == 'Status Code: 503, AWS Service: Route53, AWS Request ID: BOOGIEBOOGIE, ' +
-                'AWS Error Code: DontLikeYou, AWS Error Message: Sorry, pal.'
+        controller.flash.message == 'Sorry, pal. (Service: Route53; Status Code: 503; Error Code: DontLikeYou; ' +
+                'Request ID: BOOGIEBOOGIE)'
         response.redirectUrl == '/hostedZone/create?name=test.example.com'
         0 * _
     }
@@ -195,8 +195,8 @@ class HostedZoneControllerSpec extends Specification {
         }
         controller.flash.message == 'Could not add resource record set: ' +
                 'com.amazonaws.services.route53.model.InvalidInputException: ' +
-                'Status Code: 503, AWS Service: Route53, AWS Request ID: BOOGIEBOOGIE, ' +
-                'AWS Error Code: DontLikeYou, AWS Error Message: Sorry, pal.'
+                'Sorry, pal. (Service: Route53; Status Code: 503; Error Code: ' +
+                'DontLikeYou; Request ID: BOOGIEBOOGIE)'
         response.redirectUrl ==
                 '/hostedZone/prepareResourceRecordSet?hostedZoneId=ZATANNA&resourceRecordSetName=plain.example.com.'
         0 * _
@@ -256,8 +256,8 @@ class HostedZoneControllerSpec extends Specification {
         }
         controller.flash.message == 'Could not delete resource record set: ' +
                 'com.amazonaws.services.route53.model.InvalidInputException: ' +
-                'Status Code: 503, AWS Service: Route53, AWS Request ID: BOOGIEBOOGIE, ' +
-                'AWS Error Code: DontLikeYou, AWS Error Message: Sorry, pal.'
+                'Sorry, pal. (Service: Route53; Status Code: 503; Error Code: ' +
+                'DontLikeYou; Request ID: BOOGIEBOOGIE)'
         response.redirectUrl == '/hostedZone/show/ZATANNA'
         0 * _
         noExceptionThrown()

--- a/test/unit/com/netflix/asgard/deployment/StartDeploymentRequestSpec.groovy
+++ b/test/unit/com/netflix/asgard/deployment/StartDeploymentRequestSpec.groovy
@@ -57,7 +57,8 @@ class StartDeploymentRequestSpec extends Specification {
                     instancePriceType: "ON_DEMAND",
                     iamInstanceProfile: "BaseIAMRole",
                     associatePublicIpAddress: false,
-                    ebsOptimized: true),
+                    ebsOptimized: true,
+                    placementTenancy: "default"),
             new AutoScalingGroupBeanOptions(
                     minSize: 1,
                     maxSize: 3,
@@ -87,7 +88,8 @@ class StartDeploymentRequestSpec extends Specification {
             '"keyName":"nf-test-keypair-a","securityGroups":["sg-12345678"],' +
             '"userData":"#!/bin/bash","instanceType":"m1.large","kernelId":"123","ramdiskId":"abc",' +
             '"blockDeviceMappings":null,"instanceMonitoringIsEnabled":false,"instancePriceType":"ON_DEMAND",' +
-            '"iamInstanceProfile":"BaseIAMRole","ebsOptimized":true,"associatePublicIpAddress":false},' +
+            '"iamInstanceProfile":"BaseIAMRole","ebsOptimized":true,"associatePublicIpAddress":false,' +
+            '"placementTenancy":"default"},' +
 
             '"asgOptions":{"autoScalingGroupName":null,"launchConfigurationName":null,"minSize":1,"maxSize":3,' +
             '"desiredCapacity":2,"defaultCooldown":10,"availabilityZones":["us-west-1a"],' +

--- a/test/unit/com/netflix/asgard/model/LaunchConfigurationBeanOptionsSpec.groovy
+++ b/test/unit/com/netflix/asgard/model/LaunchConfigurationBeanOptionsSpec.groovy
@@ -38,7 +38,8 @@ class LaunchConfigurationBeanOptionsSpec extends Specification {
             instanceMonitoringIsEnabled: false,
             instancePriceType: InstancePriceType.ON_DEMAND,
             iamInstanceProfile: 'iamInstanceProfile1',
-            ebsOptimized: false
+            ebsOptimized: false,
+            placementTenancy: "default"
     )
 
     LaunchConfiguration awsLaunchConfiguration = new LaunchConfiguration(
@@ -53,7 +54,8 @@ class LaunchConfigurationBeanOptionsSpec extends Specification {
             blockDeviceMappings: [new BlockDeviceMapping(deviceName: 'deviceName1', ebs: new Ebs(volumeSize: 256))],
             instanceMonitoring: new InstanceMonitoring(enabled: false),
             iamInstanceProfile: 'iamInstanceProfile1',
-            ebsOptimized: false
+            ebsOptimized: false,
+            placementTenancy: "default"
     )
     CreateLaunchConfigurationRequest createLaunchConfigurationRequest = new CreateLaunchConfigurationRequest(
             launchConfigurationName: 'launchConfigurationName1',
@@ -67,7 +69,8 @@ class LaunchConfigurationBeanOptionsSpec extends Specification {
             blockDeviceMappings: [new BlockDeviceMapping(deviceName: 'deviceName1', ebs: new Ebs(volumeSize: 256))],
             instanceMonitoring: new InstanceMonitoring().withEnabled(false),
             iamInstanceProfile: 'iamInstanceProfile1',
-            ebsOptimized: false
+            ebsOptimized: false,
+            placementTenancy: "default"
     )
 
     def 'getCreateLaunchConfigurationRequest should have instance monitoring turned off by default'() {


### PR DESCRIPTION
Add placement tenancy option; UI for launching EBS-optimized instances. Still a WIP, pending testing.
- app/views/deployment/new.html: Add tenency selection.
- grails-app/conf/BuildConfig.groovy: update aws-java-sdk to 1.9.34.
- grails-app/controllers/com/netflix/asgard/AutoScalingController.groovy (save): set placement tenancy.
- grails-app/controllers/com/netflix/asgard/ClusterController.groovy (createNextGroup): set placement tenancy.
- grails-app/views/launchConfiguration/_launchConfigOptions.gsp: add UI elements for `ebsOptimized` and `placementTenancy`.
- src/groovy/com/netflix/asgard/model/LaunchConfigurationBeanOptions.groovy (placementTenancy): new field.
  (from, from, getCreateLaunchConfigurationRequest): pass along `placementTenancy`.
- src/groovy/com/netflix/asgard/push/GroupCreateOperation.groovy (start): set placement tenancy.
- src/groovy/com/netflix/asgard/push/GroupCreateOptions.groovy (placementTenancy): new field.
- src/groovy/com/netflix/asgard/push/RollingPushOperation.groovy (prepareGroup): pass in `placementTenancy`.
- test/unit/com/netflix/asgard/AutoScalingControllerSpec.groovy: set placement tenancy in expected results.
  Add test for setting placement tenancy.
- test/unit/com/netflix/asgard/DeploymentControllerSpec.groovy: set `placementTenancy` value.
- test/unit/com/netflix/asgard/EmailerServiceUnitSpec.groovy: fix matching of exception messages (this changed in the new SDK version).
- test/unit/com/netflix/asgard/HostedZoneControllerSpec.groovy: likewise.
- test/unit/com/netflix/asgard/deployment/StartDeploymentRequestSpec.groovy: add matching for `placementTenancy`.
- test/unit/com/netflix/asgard/model/LaunchConfigurationBeanOptionsSpec.groovy: add `placementTenancy`.
