### PR TITLE
When getting security groups from non default VPC, amazon errorCode changed

### DIFF
--- a/grails-app/services/com/netflix/asgard/AwsEc2Service.groovy
+++ b/grails-app/services/com/netflix/asgard/AwsEc2Service.groovy
@@ -492,7 +492,7 @@ class AwsEc2Service implements CacheInitializer, InitializingBean {
             group = Check.loneOrNone(result.getSecurityGroups(), SecurityGroup)
         } catch (AmazonServiceException e) {
             // Can't find a security group by name.
-            if (e.errorCode == 'InvalidParameterValue') {
+            if (e.errorCode == 'VPCIdNotSpecified') {
                 // It's likely a VPC security group which we can't reference by name. Maybe it has an ID in the cache.
                 if (cachedSecGroup) {
                     request = new DescribeSecurityGroupsRequest(groupIds: [cachedSecGroup.groupId])

--- a/test/unit/com/netflix/asgard/AwsEc2ServiceUnitSpec.groovy
+++ b/test/unit/com/netflix/asgard/AwsEc2ServiceUnitSpec.groovy
@@ -441,7 +441,7 @@ and groupName is #groupName""")
         1 * mockSecurityGroupCache.list() >> [securityGroup]
         1 * mockAmazonEC2.describeSecurityGroups(new DescribeSecurityGroupsRequest(groupNames: ['super_secure'])) >> {
             AmazonServiceException e = new AmazonServiceException('you cannot ask for a VPC Security Group by name')
-            e.errorCode = 'InvalidParameterValue'
+            e.errorCode = 'VPCIdNotSpecified'
             throw e
         }
         1 * mockAmazonEC2.describeSecurityGroups(new DescribeSecurityGroupsRequest(groupIds: ['sg-123'])) >>


### PR DESCRIPTION
Hi,

I think Amazon may've changed the api errorCode when getting a SG from a non-default VPC.

With this change now, I can create SG from applications again, and update them in the SG list page.

Regards,
Jaume Pinyol
