### PR TITLE
When getting security groups from an account without default VPC, getSecurityGroup returns null

### DIFF
--- a/grails-app/services/com/netflix/asgard/AwsEc2Service.groovy
+++ b/grails-app/services/com/netflix/asgard/AwsEc2Service.groovy
@@ -492,8 +492,8 @@ class AwsEc2Service implements CacheInitializer, InitializingBean {
             group = Check.loneOrNone(result.getSecurityGroups(), SecurityGroup)
         } catch (AmazonServiceException e) {
             // Can't find a security group by name.
-            if (e.errorCode == 'InvalidParameterValue') {
-                // It's likely a VPC security group which we can't reference by name. Maybe it has an ID in the cache.
+            if (e.errorCode == 'InvalidParameterValue' || e.errorCode == 'VPCIdNotSpecified') {
+          	// It's likely a VPC security group which we can't reference by name. Maybe it has an ID in the cache.
                 if (cachedSecGroup) {
                     request = new DescribeSecurityGroupsRequest(groupIds: [cachedSecGroup.groupId])
                     DescribeSecurityGroupsResult result = awsClient.by(region).describeSecurityGroups(request)


### PR DESCRIPTION
Hi,

Amazon errorCode when getting an SG from an account without default VPC is VPCIdNotSpecified.

With this change, SG for applications can be created and updated from the application show page, and update them in the SG list page, when the account has no default VPC.

Regards,
Jaume Pinyol
